### PR TITLE
Issue8 date format should be iso8601

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml.ComponentModel/DateTimeConverter.cs
+++ b/src/Portable.Xaml/Portable.Xaml.ComponentModel/DateTimeConverter.cs
@@ -3,50 +3,81 @@ using System.Collections;
 using System.Globalization;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Portable.Xaml.ComponentModel
 {
 
 	public class DateTimeConverter : TypeConverter
 	{
-		public override bool CanConvertFrom (ITypeDescriptorContext context, Type sourceType)
+		private static readonly Regex UtcTidyUpPattern = new Regex(@"0+Z$");
+
+		private static readonly Regex LocalTidyUpPatterns = new Regex(@"0+$");
+
+		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom (context, sourceType);
+			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
 		}
 
-		public override bool CanConvertTo (ITypeDescriptorContext context, Type destinationType)
+		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
 		{
-			return destinationType == typeof(string) || base.CanConvertTo (context, destinationType);
+			return destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
 		}
 
-		public override object ConvertFrom (ITypeDescriptorContext context, CultureInfo culture, object value)
+		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
 			var text = value as string;
 			if (text != null)
-				return DateTime.Parse (text, culture ?? CultureInfo.CurrentCulture);
-			return base.ConvertFrom (context, culture, value);
+				return DateTime.Parse(text, culture ?? CultureInfo.CurrentCulture);
+			return base.ConvertFrom(context, culture, value);
 		}
 
-		public override object ConvertTo (ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
 		{
 			if (destinationType == typeof(string) && value is DateTime)
-            {
-                culture = culture ?? CultureInfo.CurrentCulture;
+			{
+				culture = culture ?? CultureInfo.CurrentCulture;
 
-                var date = (DateTime)value;
-                var hasTime = date.TimeOfDay.TotalSeconds > 0;
-                if (culture == CultureInfo.InvariantCulture)
-                    return hasTime ? date.ToString(culture) : date.ToString("yyyy-MM-dd", culture);
+				var date = (DateTime)value;
+				var hasTime = date.TimeOfDay.TotalSeconds > 0;
+				if (culture == CultureInfo.InvariantCulture)
+				{
+					if (hasTime)
+					{
+						// To exactly match the behaviour of System.Xaml unnecessary zeros must be removed from the end of the time.
+						return RemoveUnnecessaryZeros(date.ToString("o", culture), date.Kind);
+					}
 
-                var dateTimeFormat = culture.DateTimeFormat;
-                string format = dateTimeFormat.ShortDatePattern;
-                if (hasTime)
-                    format += " " + dateTimeFormat.ShortTimePattern;
+					return date.ToString("yyyy-MM-dd", culture);
+				}
 
-                return date.ToString(format, culture);
-            }
-			return base.ConvertTo (context, culture, value, destinationType);
+				var dateTimeFormat = culture.DateTimeFormat;
+				string format = dateTimeFormat.ShortDatePattern;
+				if (hasTime)
+					format += " " + dateTimeFormat.ShortTimePattern;
+
+				return date.ToString(format, culture);
+			}
+			return base.ConvertTo(context, culture, value, destinationType);
+		}
+
+		private string RemoveUnnecessaryZeros(string dateFormatted, DateTimeKind kind)
+		{
+			string conciseDate = dateFormatted.Trim();
+			if (kind == DateTimeKind.Utc)
+			{
+				conciseDate = UtcTidyUpPattern.Replace(conciseDate, "Z");
+				if (conciseDate.EndsWith(".Z"))
+					conciseDate = conciseDate.Remove(conciseDate.Length - 2, 1);
+			}
+			else
+			{
+				conciseDate = LocalTidyUpPatterns.Replace(conciseDate, "");
+				if (conciseDate.EndsWith("."))
+					conciseDate = conciseDate.Substring(0, conciseDate.Length - 1);
+			}
+
+			return conciseDate;
 		}
 	}
-
 }

--- a/src/Portable.Xaml/Portable.Xaml.ComponentModel/NullableConverter.cs
+++ b/src/Portable.Xaml/Portable.Xaml.ComponentModel/NullableConverter.cs
@@ -49,5 +49,16 @@ namespace Portable.Xaml.ComponentModel
 				return UnderlyingTypeConverter.ConvertFrom(context, culture, value);
 			return base.ConvertFrom(context, culture, value);
 		}
+
+		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+		{
+			if (destinationType == null) throw new ArgumentNullException(nameof(destinationType));
+
+			if (destinationType == typeof (string) && UnderlyingTypeConverter != null && value != null)
+			{
+				return UnderlyingTypeConverter.ConvertTo(context, culture, value, destinationType);
+			}
+			return GetConvertToException(value, destinationType);
+		}
 	}
 }

--- a/src/Test/Compat.cs
+++ b/src/Test/Compat.cs
@@ -36,6 +36,7 @@ namespace MonoTests.Portable.Xaml
 		public static string UpdateXml(this string str)
 		{
 			return str.Replace ("net_4_0", Compat.Version)
+				.Replace("net_4_5", Compat.Version)
 				.Replace ("clr-namespace:Portable.Xaml;assembly=Portable.Xaml", $"clr-namespace:{Compat.Namespace};assembly={Compat.Namespace}")
 				.Replace ($" px:", $" {Compat.Prefix}:")
 				.Replace ($"xmlns:px", $"xmlns:{Compat.Prefix}")

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -236,6 +236,11 @@ namespace MonoTests.Portable.Xaml
 		}
 	}
 
+	public class TestClass6
+	{
+		public DateTime TheDateAndTime { get; set; }
+	}
+
 	public class MyExtension : MarkupExtension
 	{
 		public MyExtension ()
@@ -919,6 +924,11 @@ namespace MonoTests.Portable.Xaml
 	public class NullableContainer
 	{
 		public int? TestProp { get; set; }
+	}
+
+	public class NullableContainer2
+	{
+		public DateTime? NullableDate { get; set; }
 	}
 
 	class TestStructConverter : TypeConverter

--- a/src/Test/System.Xaml/XamlXmlWriterTest.cs
+++ b/src/Test/System.Xaml/XamlXmlWriterTest.cs
@@ -663,6 +663,52 @@ namespace MonoTests.Portable.Xaml
 		}
 
 		[Test]
+		public void Write_DateTime_UtcWithNoMilliseconds()
+		{
+			var testData = new TestClass6 {TheDateAndTime = new DateTime(2015, 12, 30, 23, 50, 51, DateTimeKind.Utc)};
+			var result = XamlServices.Save(testData);
+			Assert.AreEqual(ReadXml("DateTime2.xml"), result, "#2");
+		}
+
+		[Test]
+		public void Write_DateTime_UtcWithMilliseconds()
+		{
+			var testData = new TestClass6 { TheDateAndTime = new DateTime(2015, 12, 30, 23, 50, 51, DateTimeKind.Utc) };
+			testData.TheDateAndTime = testData.TheDateAndTime.AddMilliseconds(11);
+			var result = XamlServices.Save(testData);
+			Assert.AreEqual(ReadXml("DateTime3.xml"), result, "#3");
+		}
+
+		[Test]
+		public void Write_DateTime_LocalWithMilliseconds()
+		{
+			var usTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+			var localisedDateTime = TimeZoneInfo.ConvertTimeFromUtc(
+				new DateTime(2015, 12, 30, 23, 50, 51, DateTimeKind.Utc),
+				usTimeZone);
+			var testData = new TestClass6 { TheDateAndTime = localisedDateTime };
+			testData.TheDateAndTime = testData.TheDateAndTime.AddMilliseconds(11);
+			var result = XamlServices.Save(testData);
+			Assert.AreEqual(ReadXml("DateTime4.xml"), result, "#4");
+		}
+
+		[Test]
+		public void Write_DateTime_WithNoTimeThatEndsWithZero()
+		{
+			var testData = new TestClass6 { TheDateAndTime = new DateTime(2015, 12, 30) };
+			var result = XamlServices.Save(testData);
+			Assert.AreEqual(ReadXml("DateTime5.xml"), result, "#5");
+		}
+
+		[Test]
+		public void Write_NullableDateTime_UtcWithNoMilliseconds()
+		{
+			var testData = new NullableContainer2 { NullableDate = new DateTime(2015, 12, 30, 23, 50, 51, DateTimeKind.Utc) };
+			var result = XamlServices.Save(testData);
+			Assert.AreEqual(ReadXml("DateTime6.xml"), result, "#6");
+		}
+
+		[Test]
 		public void Write_TimeSpan ()
 		{
 			Assert.AreEqual (ReadXml ("TimeSpan.xml"), XamlServices.Save (TimeSpan.FromMinutes (7)), "#1");

--- a/src/Test/XmlFiles/DateTime2.xml
+++ b/src/Test/XmlFiles/DateTime2.xml
@@ -1,0 +1,1 @@
+﻿<TestClass6 TheDateAndTime="2015-12-30T23:50:51Z" xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_5" />

--- a/src/Test/XmlFiles/DateTime3.xml
+++ b/src/Test/XmlFiles/DateTime3.xml
@@ -1,0 +1,1 @@
+﻿<TestClass6 TheDateAndTime="2015-12-30T23:50:51.011Z" xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_5" />

--- a/src/Test/XmlFiles/DateTime4.xml
+++ b/src/Test/XmlFiles/DateTime4.xml
@@ -1,0 +1,1 @@
+﻿<TestClass6 TheDateAndTime="2015-12-30T15:50:51.011" xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_5" />

--- a/src/Test/XmlFiles/DateTime5.xml
+++ b/src/Test/XmlFiles/DateTime5.xml
@@ -1,0 +1,1 @@
+﻿<TestClass6 TheDateAndTime="2015-12-30" xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_5" />

--- a/src/Test/XmlFiles/DateTime6.xml
+++ b/src/Test/XmlFiles/DateTime6.xml
@@ -1,0 +1,1 @@
+﻿<NullableContainer2 NullableDate="2015-12-30T23:50:51Z" xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_5" />


### PR DESCRIPTION
Fixes #8 
By default serialisation will format dates using ISO8601 format. For example
2015-12-30T23:50:51Z (UTC Date and time)
2015-12-30T15:50:51.011 (Local Date and time)

Using the standard .NET 4+ format "o" the returns trailing zeros padded out to 7 digits.
2015-12-30T23:50:51.0000000Z
However the System.Xaml.dll library was built prior and it does not include the trailing zeros.  So to match the behaviour of this I've added an extra function (RemoveUnnecessaryZeros) in DateTimeConverter.cs.

Let me know if there's anything else in there you'd like me to change.  