### PR TITLE
Implements immutable collection support

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml.Schema/XamlTypeInvoker.cs
+++ b/src/Portable.Xaml/Portable.Xaml.Schema/XamlTypeInvoker.cs
@@ -199,7 +199,7 @@ namespace Portable.Xaml.Schema
 				var assembly = ti.Assembly;
 				var name = ti.GetGenericTypeDefinition().FullName;
 				var builderType = assembly.GetType(name.Substring(0, name.Length - 2)); // remove `1 or `2
-				var mi = builderType.GetTypeInfo().GetDeclaredMethods("CreateRange").FirstOrDefault(r => r.GetParameters().Length == 1);
+				var mi = builderType.GetRuntimeMethods().FirstOrDefault(r => r.Name == "CreateRange" && r.GetParameters().Length == 1);
 				createImmutableFromMutable = mi.MakeGenericMethod(typeArgs);
 			}
 			return createImmutableFromMutable.Invoke(null, new[] { instance });

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectNodeIterator.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectNodeIterator.cs
@@ -247,7 +247,6 @@ namespace Portable.Xaml
 				if (settings.LocalAssembly == typeAssembly)
 					return true;
 				var typeName = typeAssembly.GetName();
-				var typePk = typeName.GetPublicKeyToken();
 				var internalsVisible = type.GetTypeInfo().Assembly.GetCustomAttributes<InternalsVisibleToAttribute>();
 				foreach (var iv in internalsVisible)
 				{

--- a/src/Test/Portable.Xaml-tests-net_4_5.csproj
+++ b/src/Test/Portable.Xaml-tests-net_4_5.csproj
@@ -116,6 +116,9 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System.Xaml" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Test/Portable.Xaml-tests-pcl259.csproj
+++ b/src/Test/Portable.Xaml-tests-pcl259.csproj
@@ -115,6 +115,9 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -34,7 +34,9 @@ using System.Xml.Schema;
 using System.Xml.Serialization;
 using NUnit.Framework;
 using sc = System.ComponentModel;
+#if !PCL136
 using System.Collections.Immutable;
+#endif
 
 
 #if PCL
@@ -1419,6 +1421,8 @@ namespace MonoTests.Portable.Xaml
 		}
 	}
 
+	#if !PCL136
+
 	public class ImmutableCollectionContainer
 	{
 		public ImmutableArray<ImmutableCollectionItem> ImmutableArray { get; set; }
@@ -1430,6 +1434,8 @@ namespace MonoTests.Portable.Xaml
 		public ImmutableDictionary<string, ImmutableCollectionItem> ImmutableDictionary { get; set; }
 		public ImmutableSortedDictionary<string, ImmutableCollectionItem> ImmutableSortedDictionary { get; set; }
 	}
+
+	#endif
 }
 
 namespace XamlTest

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -34,6 +34,7 @@ using System.Xml.Schema;
 using System.Xml.Serialization;
 using NUnit.Framework;
 using sc = System.ComponentModel;
+using System.Collections.Immutable;
 
 
 #if PCL
@@ -1406,6 +1407,28 @@ namespace MonoTests.Portable.Xaml
 		}
 
 		public string Foo { get; set; }
+	}
+
+	public class ImmutableCollectionItem : IComparable
+	{
+		public string Foo { get; set; }
+
+		public int CompareTo(object obj)
+		{
+			return string.Compare(Foo, ((ImmutableCollectionItem)obj)?.Foo);
+		}
+	}
+
+	public class ImmutableCollectionContainer
+	{
+		public ImmutableArray<ImmutableCollectionItem> ImmutableArray { get; set; }
+		public ImmutableList<ImmutableCollectionItem> ImmutableList { get; set; }
+		public ImmutableHashSet<ImmutableCollectionItem> ImmutableHashSet { get; set; }
+		public ImmutableQueue<ImmutableCollectionItem> ImmutableQueue { get; set; }
+		public ImmutableStack<ImmutableCollectionItem> ImmutableStack { get; set; }
+		public ImmutableSortedSet<ImmutableCollectionItem> ImmutableSortedSet { get; set; }
+		public ImmutableDictionary<string, ImmutableCollectionItem> ImmutableDictionary { get; set; }
+		public ImmutableSortedDictionary<string, ImmutableCollectionItem> ImmutableSortedDictionary { get; set; }
 	}
 }
 

--- a/src/Test/System.Xaml/XamlNodeListTest.cs
+++ b/src/Test/System.Xaml/XamlNodeListTest.cs
@@ -82,7 +82,7 @@ namespace MonoTests.Portable.Xaml
 			list.Writer.WriteStartObject(sc.GetXamlType(typeof(TestClass4)));
 			list.Writer.WriteEndObject();
 			list.Writer.Close();
-			var reader = list.GetReader();
+			list.GetReader();
 		}
 	}
 }

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -1723,7 +1723,7 @@ namespace MonoTests.Portable.Xaml
 				Assert.Ignore("Not supported in System.Xaml");
 			// can't find constructor
 			using (var xr = GetReader ("ImmutableTypeMultipleConstructors3.xml")) {
-				var res = (ImmutableTypeMultipleConstructors)XamlServices.Load(xr);
+				XamlServices.Load(xr);
 			}
 		}
 
@@ -1736,7 +1736,7 @@ namespace MonoTests.Portable.Xaml
 				Assert.Ignore("Not supported in System.Xaml");
 			// found constructor, but one of the properties set is read only
 			using (var xr = GetReader ("ImmutableTypeMultipleConstructors4.xml")) {
-				var res = (ImmutableTypeMultipleConstructors)XamlServices.Load(xr);
+				XamlServices.Load(xr);
 			}
 		}
 

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -1800,6 +1800,7 @@ namespace MonoTests.Portable.Xaml
 			}
 		}
 
+		#if !PCL136
 		[Test]
 		public void Write_ImmutableCollectionContainer()
 		{
@@ -1829,5 +1830,6 @@ namespace MonoTests.Portable.Xaml
 				CollectionAssert.AreEqual(expected, res.ImmutableSortedSet.Select(r => r.Foo), "#7-2");
 			}
 		}
+		#endif
 	}
 }

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -1799,5 +1799,35 @@ namespace MonoTests.Portable.Xaml
 				Assert.AreEqual("There", res.Foo, "#4");
 			}
 		}
+
+		[Test]
+		public void Write_ImmutableCollectionContainer()
+		{
+			if (!Compat.IsPortableXaml)
+				Assert.Ignore("Not supported in System.Xaml");
+			using (var xr = GetReader ("ImmutableCollectionContainer.xml")) {
+				var res = (ImmutableCollectionContainer)XamlServices.Load(xr);
+				Assert.IsNotNull(res, "#1");
+
+				var expected = new [] { "Item1", "Item2", "Item3" };
+				Assert.IsFalse(res.ImmutableArray.IsDefaultOrEmpty, "#2-1");
+				CollectionAssert.AreEqual(expected, res.ImmutableArray.Select(r => r.Foo), "#2-2");
+
+				Assert.IsFalse(res.ImmutableList.IsEmpty, "#3-1");
+				CollectionAssert.AreEqual(expected, res.ImmutableList.Select(r => r.Foo), "#3-2");
+
+				Assert.IsFalse(res.ImmutableQueue.IsEmpty, "#4-1");
+				CollectionAssert.AreEqual(expected, res.ImmutableQueue.Select(r => r.Foo), "#4-2");
+
+				Assert.IsFalse(res.ImmutableHashSet.IsEmpty, "#5-1");
+				CollectionAssert.AreEquivalent(expected, res.ImmutableHashSet.Select(r => r.Foo), "#5-2");
+
+				Assert.IsFalse(res.ImmutableStack.IsEmpty, "#6-1");
+				CollectionAssert.AreEqual(expected.Reverse(), res.ImmutableStack.Select(r => r.Foo), "#6-2");
+
+				Assert.IsFalse(res.ImmutableSortedSet.IsEmpty, "#7-1");
+				CollectionAssert.AreEqual(expected, res.ImmutableSortedSet.Select(r => r.Foo), "#7-2");
+			}
+		}
 	}
 }

--- a/src/Test/XmlFiles/ImmutableCollectionContainer.xml
+++ b/src/Test/XmlFiles/ImmutableCollectionContainer.xml
@@ -1,0 +1,49 @@
+<ImmutableCollectionContainer xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sci="clr-namespace:System.Collections.Immutable;assembly=System.Collections.Immutable">
+  <ImmutableCollectionContainer.ImmutableList>
+    <sci:ImmutableList x:TypeArguments="ImmutableCollectionItem">
+      <ImmutableCollectionItem Foo="Item1" />
+      <ImmutableCollectionItem Foo="Item2" />
+      <ImmutableCollectionItem Foo="Item3" />
+    </sci:ImmutableList>
+  </ImmutableCollectionContainer.ImmutableList>
+  	<ImmutableCollectionContainer.ImmutableArray>
+		<ImmutableCollectionItem Foo="Item1" />
+		<ImmutableCollectionItem Foo="Item2" />
+		<ImmutableCollectionItem Foo="Item3" />
+	</ImmutableCollectionContainer.ImmutableArray>
+	<!--ImmutableCollectionContainer.ImmutableList>
+		<ImmutableCollectionItem Foo="Item1" />
+		<ImmutableCollectionItem Foo="Item2" />
+		<ImmutableCollectionItem Foo="Item3" />
+	</ImmutableCollectionContainer.ImmutableList-->
+	<ImmutableCollectionContainer.ImmutableHashSet>
+		<ImmutableCollectionItem Foo="Item1" />
+		<ImmutableCollectionItem Foo="Item2" />
+		<ImmutableCollectionItem Foo="Item3" />
+	</ImmutableCollectionContainer.ImmutableHashSet>
+	<ImmutableCollectionContainer.ImmutableQueue>
+		<ImmutableCollectionItem Foo="Item1" />
+		<ImmutableCollectionItem Foo="Item2" />
+		<ImmutableCollectionItem Foo="Item3" />
+	</ImmutableCollectionContainer.ImmutableQueue>
+	<ImmutableCollectionContainer.ImmutableStack>
+		<ImmutableCollectionItem Foo="Item1" />
+		<ImmutableCollectionItem Foo="Item2" />
+		<ImmutableCollectionItem Foo="Item3" />
+	</ImmutableCollectionContainer.ImmutableStack>
+	<ImmutableCollectionContainer.ImmutableSortedSet>
+		<ImmutableCollectionItem Foo="Item2" />
+		<ImmutableCollectionItem Foo="Item1" />
+		<ImmutableCollectionItem Foo="Item3" />
+	</ImmutableCollectionContainer.ImmutableSortedSet>
+	<ImmutableCollectionContainer.ImmutableDictionary>
+		<ImmutableCollectionItem Foo="Item1" x:Key="0" />
+		<ImmutableCollectionItem Foo="Item2" x:Key="1" />
+		<ImmutableCollectionItem Foo="Item3" x:Key="2" />
+	</ImmutableCollectionContainer.ImmutableDictionary>
+	<ImmutableCollectionContainer.ImmutableSortedDictionary>
+		<ImmutableCollectionItem Foo="Item1" x:Key="0" />
+		<ImmutableCollectionItem Foo="Item2" x:Key="1" />
+		<ImmutableCollectionItem Foo="Item3" x:Key="2" />
+	</ImmutableCollectionContainer.ImmutableSortedDictionary>
+</ImmutableCollectionContainer>

--- a/src/Test/packages.config
+++ b/src/Test/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is done as a PR for now to discuss the added API to implement issue #11.

What has been added:

- `XamlType.IsImmutable` - boolean property that determines if the type is immutable and needs construction
- `XamlType.LookupIsImmutable` - can be overridden to provide your own support for immutable types.
- `XamlTypeInvoker.ToMutable()` - Called after construction or getting the existing value to translate to a mutable type (e.g. `List<>` or `Dictionary<,>`)
- `XamlTypeInvoker.ToImmutable()` - Called after the object has been parsed, to create the Immutable type from the mutable instance.

There is a current implementation using these properties to fully support immutable collections and dictionaries.

@wieslawsoltes let me know if you have any feedback concerning this.  I have investigated using existing API's as you have and found it really isn't set up to properly deal with immutable collection types. Overriding `XamlMemberInvoker` seems to be the incorrect place to handle this as it'd only handle when setting a property of a container, and this is really a behaviour of the type itself.

Any thoughts or feedback would be greatly appreciated!