### PR TITLE
Fixing bug: Escape characters not supported in markup extensions

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
@@ -144,7 +144,7 @@ namespace Portable.Xaml
 				idx = s.IndexOf (escape.Value, startIndex, numCharacters);
 			}
 
-			if (idx > 0)
+			if (numCharacters > 0)
 				sb.Append (s.Substring (startIndex, numCharacters));
 
 			return sb.ToString ();

--- a/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
@@ -233,27 +233,27 @@ namespace Portable.Xaml
 		{
 			switch (Current)
 			{
-				case '{':
-					var markup = ReadMarkup();
-					if (markup != null)
-					{
-						ReadUntil(',', true, escape: '\\');
-						return markup;
-					}
-					break;
-				case '\'':
-				case '"':
-					var idx = index;
-					var endch = Current;
-					index++;
-					var val = ReadUntil(endch, escape: '\\');
-					if (val != null)
-					{
-						ReadUntil(',', true, escape: '\\');
-						return val;
-					}
-					index = idx;
-					break;
+			case '{':
+				var markup = ReadMarkup();
+				if (markup != null)
+				{
+					ReadUntil(',', true, escape: '\\');
+					return markup;
+				}
+				break;
+			case '\'':
+			case '"':
+				var idx = index;
+				var endch = Current;
+				index++;
+				var val = ReadUntil(endch, escape: '\\');
+				if (val != null)
+				{
+					ReadUntil(',', true, escape: '\\');
+					return val;
+				}
+				index = idx;
+				break;
 			}
 			return null;
 		}

--- a/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
@@ -26,241 +26,315 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using Portable.Xaml.Schema;
+using System.Text;
 
 namespace Portable.Xaml
 {
-	internal class ParsedMarkupExtensionInfo
-	{
-		Dictionary<XamlMember,object> args = new Dictionary<XamlMember,object> ();
-		IXamlNamespaceResolver nsResolver;
-		XamlSchemaContext sctx;
+    internal class ParsedMarkupExtensionInfo
+    {
+        Dictionary<XamlMember,object> args = new Dictionary<XamlMember,object> ();
+        IXamlNamespaceResolver nsResolver;
+        XamlSchemaContext sctx;
 
-		string value;
-		int index;
-		List<object> positionalParameters;
-		XamlMember member;
+        string value;
+        int index;
+        List<object> positionalParameters;
+        XamlMember member;
 
-		public string Name { get; set; }
-		public XamlType Type { get; set; }
+        public string Name { get; set; }
+        public XamlType Type { get; set; }
 
-		public Dictionary<XamlMember,object> Arguments
-		{
-			get { return args; }
-		}
+        public Dictionary<XamlMember,object> Arguments
+        {
+            get { return args; }
+        }
 
 
-		public ParsedMarkupExtensionInfo(string value, IXamlNamespaceResolver nsResolver, XamlSchemaContext sctx)
-		{
-			if (value == null)
-				throw new ArgumentNullException ("value");
-			this.value = value;
-			this.nsResolver = nsResolver;
-			this.sctx = sctx;
-		}
+        public ParsedMarkupExtensionInfo(string value, IXamlNamespaceResolver nsResolver, XamlSchemaContext sctx)
+        {
+            if (value == null)
+                throw new ArgumentNullException ("value");
+            this.value = value;
+            this.nsResolver = nsResolver;
+            this.sctx = sctx;
+        }
 
-		public ParsedMarkupExtensionInfo()
-		{
-		}
+        public ParsedMarkupExtensionInfo()
+        {
+        }
 
-		public ParsedMarkupExtensionInfo(ParsedMarkupExtensionInfo info)
-		{
-			this.value = info.value;
-			this.index = info.index;
-			this.nsResolver = info.nsResolver;
-			this.sctx = info.sctx;
-		}
+        public ParsedMarkupExtensionInfo(ParsedMarkupExtensionInfo info)
+        {
+            this.value = info.value;
+            this.index = info.index;
+            this.nsResolver = info.nsResolver;
+            this.sctx = info.sctx;
+        }
 
-		string ReadRest()
-		{
-			var endidx = value.IndexOf ('}', index);
-			string val;
-			if (endidx >= 0)
-			{
-				val = value.Substring(index, endidx - index);
-				index = endidx;
-			}
-			else
-			{
-				val = value.Substring(index);
-				index = value.Length;
-			}
-			return val;
-		}
+        string ReadRest()
+        {
+            var endidx = value.IndexOf ('}', index);
+            string val;
+            if (endidx >= 0)
+            {
+                val = value.Substring(index, endidx - index);
+                index = endidx;
+            }
+            else
+            {
+                val = value.Substring(index);
+                index = value.Length;
+            }
+            return val;
+        }
 
-		string ReadUntil (char ch, bool readToEnd = false, bool skip = true)
-		{
-			return ReadUntil (new [] { ch }, readToEnd, skip);
-		}
+        string ReadUntil (char ch, bool readToEnd = false, bool skip = true, char? escape = null)
+        {
+            return ReadUntil (new [] { ch }, readToEnd, skip, escape);
+        }
 
-		string ReadUntil (char[] ch, bool readToEnd = false, bool skip = true)
-		{
-			var endidx = value.IndexOf ('}', index);
-			var idx = value.IndexOfAny (ch, index);
-			string val = null;
-			if (idx >= 0 && idx <= endidx) {
-				val = value.Substring (index, idx - index);
-				index = skip ? idx + 1 : idx;
-			}
-			else if (readToEnd) {
-				if (endidx >= 0)
-					val = value.Substring (index, endidx - index);
-				else
-					val = value.Substring (index);
-				index = endidx == -1 ? value.Length : endidx;
-			}
-			return val;
-		}
+        string ReadUntil (char[] ch, bool readToEnd = false, bool skip = true, char? escape = null)
+        {
+            var endidx = IndexOfAnyEscaped (new char[] { '}' }, value, escape, index);
+            var idx = IndexOfAnyEscaped (ch, value, escape, index);
+            string val = null;
+            if (idx >= 0 && idx <= endidx)
+            {
+                val = SubstringWithEscape (value, index, idx - index, escape);
+                index = skip ? idx + 1 : idx;
+            }
+            else if (readToEnd)
+            {
+                if (endidx >= 0)
+                    val = SubstringWithEscape (value, index, endidx - index, escape);
+                else
+                    val = SubstringWithEscape (value, index, escape);
+                index = endidx == -1 ? value.Length : endidx;
+            }
 
-		void ReadWhitespace ()
-		{
-			while (index < value.Length && char.IsWhiteSpace (value [index])) {
-				index++;
-			}
-		}
+            return val;
+        }
 
-		bool ReadWhitespaceUntil (char ch)
-		{
-			var old = index;
-			while (index < value.Length && char.IsWhiteSpace (value [index])) {
-				index++;
-			}
-			if (Current == ch)
-			{
-				index++;
-				return true;
-			}
-			index = old;
-			return false;
-		}
+        string SubstringWithEscape (string s, int startIndex, char? escape)
+        {
+            return SubstringWithEscape (s, startIndex, s.Length - startIndex, escape);
+        }
 
-		bool Read(char ch)
-		{
-			if (Current == ch) {
-				index++;
-				return true;
-			}
-			return false;
-		}
+        string SubstringWithEscape (string s, int startIndex, int numCharacters, char? escape)
+        {
+            // If we aren't even using escapes, use the faster method
+            if (escape == null)
+                return s.Substring (startIndex, numCharacters);
 
-		void AddPositionalParameter (object value)
-		{
-			if (positionalParameters == null) {
-				positionalParameters = new List<object> ();
-				if (Arguments.Count > 0)
-				{
-					// positional parameters can't come after non-positional parameters
-					throw Error("Unexpected positional parameter in expression '{0}'", this.value);
-				}
-				Arguments.Add (XamlLanguage.PositionalParameters, positionalParameters);
-			}
-			positionalParameters.Add (value);
-		}
+            int idx = s.IndexOf (escape.Value, startIndex, numCharacters);
 
-		object ParseEscapedValue()
-		{
-			switch (Current)
-			{
-			case '{':
-				var markup = ReadMarkup();
-				if (markup != null)
-				{
-					ReadUntil(',', true);
-					return markup;
-				}
-				break;
-			case '\'':
-			case '"':
-				var idx = index;
-				var endch = Current;
-				index++;
-				var val = ReadUntil(endch);
-				if (val != null)
-				{
-					ReadUntil (',', true);
-					return val;
-				}
-				index = idx;
-				break;
-			}
-			return null;
-		}
+            // If the string contains no escape characters, use the faster method
+            if (idx < 0 || idx >= startIndex + numCharacters)
+                return s.Substring (startIndex, numCharacters);
 
-		bool ParseArgument ()
-		{
-			ReadWhitespace();
-			var escapedValue = ParseEscapedValue ();
-			if (escapedValue != null) {
-				AddPositionalParameter(escapedValue);
-				ParseArgument();
-				return true;
-			}
+            StringBuilder sb = new StringBuilder (s.Length);
+            while (idx >= 0 && idx < startIndex + numCharacters)
+            {
+                if (idx - startIndex > 0)
+                    sb.Append (s.Substring (startIndex, idx - startIndex));
+                if (idx + 1 < s.Length)
+                    sb.Append (s[idx + 1]);
+                numCharacters -= (idx - startIndex + 2);
+                startIndex = idx + 2;
+                idx = s.IndexOf (escape.Value, startIndex, numCharacters);
+            }
 
-			var name = ReadUntil(new [] { '=', ' ', ',' }, readToEnd: true, skip: false);
-			if (string.IsNullOrEmpty(name))
-				return false;
-			if (!ReadWhitespaceUntil('='))
-			{
-				AddPositionalParameter(name + ReadUntil(',', true).TrimEnd());
-				ParseArgument();
-				return true;
-			}
-			member = Type.GetMember (name) ?? new XamlMember (name, Type, false);
-			ReadWhitespace ();
-			ParseValue ();
-			return true;
-		}
+            if (idx > 0)
+                sb.Append (s.Substring (startIndex, numCharacters));
 
-		char Current { get { return index < value.Length ? value [index] : unchecked((char)-1); } }
+            return sb.ToString ();
+        }
 
-		bool Finished { get { return index >= value.Length; } }
+        int IndexOfAnyEscaped (char[] ch, string value, char? escape, int startIdx)
+        {
+            if (escape == null)
+                return value.IndexOfAny(ch, startIdx);
 
-		ParsedMarkupExtensionInfo ReadMarkup()
-		{
-			var info = new ParsedMarkupExtensionInfo (this);
-			try {
-				info.Parse ();
-				index = info.index;
-				return info;
-			} catch {
-			}
-			return null;
-		}
+            int idx = 0, nextStart = startIdx;
 
-		void ParseValue()
-		{
-			var escapedValue = ParseEscapedValue ();
-			if (escapedValue != null) {
-				Arguments.Add (member, escapedValue);
-				ParseArgument();
-				return;
-			}
+            do
+            {
+                idx = ch.Length == 1 ? value.IndexOf (ch[0], nextStart) : value.IndexOfAny (ch, nextStart);
+                nextStart = idx + 1;
 
-			var val = ReadUntil (',', true);
+                // If no good match, return; otherwise, check for escape characters
+                if (idx < 0 || idx >= value.Length)
+                    break;
+                else
+                {
+                    // We need to handle repetitions. If there are an odd number of escape characters behind us, we
+                    // are escaped; if an even number, we aren't escaped.
+                    int numEscapes = 0;
+                    for (int i = idx - 1; i >=0 && value [i] == escape.Value; i--)
+                    {
+                        ++numEscapes;
+                    }
+
+                    if (numEscapes % 2 == 0)
+                        break;
+                }
+            }
+            while (true);
+
+            return idx;
+        }
+
+        void ReadWhitespace ()
+        {
+            while (index < value.Length && char.IsWhiteSpace (value [index])) {
+                index++;
+            }
+        }
+
+        bool ReadWhitespaceUntil (char ch)
+        {
+            var old = index;
+            while (index < value.Length && char.IsWhiteSpace (value [index])) {
+                index++;
+            }
+            if (Current == ch)
+            {
+                index++;
+                return true;
+            }
+            index = old;
+            return false;
+        }
+
+        bool Read(char ch)
+        {
+            if (Current == ch) {
+                index++;
+                return true;
+            }
+            return false;
+        }
+
+        void AddPositionalParameter (object value)
+        {
+            if (positionalParameters == null) {
+                positionalParameters = new List<object> ();
+                if (Arguments.Count > 0)
+                {
+                    // positional parameters can't come after non-positional parameters
+                    throw Error("Unexpected positional parameter in expression '{0}'", this.value);
+                }
+                Arguments.Add (XamlLanguage.PositionalParameters, positionalParameters);
+            }
+            positionalParameters.Add (value);
+        }
+
+        object ParseEscapedValue()
+        {
+            switch (Current)
+            {
+                case '{':
+                    var markup = ReadMarkup();
+                    if (markup != null)
+                    {
+                        ReadUntil(',', true, escape: '\\');
+                        return markup;
+                    }
+                    break;
+                case '\'':
+                case '"':
+                    var idx = index;
+                    var endch = Current;
+                    index++;
+                    var val = ReadUntil(endch, escape: '\\');
+                    if (val != null)
+                    {
+                        ReadUntil(',', true, escape: '\\');
+                        return val;
+                    }
+                    index = idx;
+                    break;
+            }
+            return null;
+        }
+
+        bool ParseArgument ()
+        {
+            ReadWhitespace();
+            var escapedValue = ParseEscapedValue ();
+            if (escapedValue != null)
+            {
+                AddPositionalParameter(escapedValue);
+                ParseArgument();
+                return true;
+            }
+
+            var name = ReadUntil(new [] { '=', ' ', ',' }, readToEnd: true, skip: false, escape: '\\');
+            if (string.IsNullOrEmpty(name))
+                return false;
+            if (!ReadWhitespaceUntil('='))
+            {
+                AddPositionalParameter(name + ReadUntil(',', true, escape: '\\').TrimEnd());
+                ParseArgument();
+                return true;
+            }
+            member = Type.GetMember (name) ?? new XamlMember(name, Type, false);
+            ReadWhitespace ();
+            ParseValue ();
+            return true;
+        }
+
+        char Current { get { return index < value.Length ? value [index] : unchecked((char)-1); } }
+
+        bool Finished { get { return index >= value.Length; } }
+
+        ParsedMarkupExtensionInfo ReadMarkup()
+        {
+            var info = new ParsedMarkupExtensionInfo (this);
+            try {
+                info.Parse ();
+                index = info.index;
+                return info;
+            } catch {
+            }
+            return null;
+        }
+
+        void ParseValue()
+        {
+            var escapedValue = ParseEscapedValue ();
+            if (escapedValue != null) {
+                Arguments.Add (member, escapedValue);
+                ParseArgument();
+                return;
+            }
+
+            var val = ReadUntil(',', true, escape: '\\');
 			val = val.Trim ();
-			Arguments.Add (member, val);
-			if (!ParseArgument()) {
-				Arguments [member] = val + ReadRest ();
-			}
-		}
+            Arguments.Add (member, val);
+            if (!ParseArgument()) {
+                Arguments [member] = val + ReadRest ();
+            }
+        }
 
-		public void Parse ()
-		{
-			if (!Read('{'))
-				throw Error ("Invalid markup extension attribute. It should begin with '{{', but was {0}", value);
-			Name = ReadUntil (' ', true);
-			XamlTypeName xtn;
-			if (!XamlTypeName.TryParse (Name, nsResolver, out xtn))
-				throw Error ("Failed to parse type name '{0}'", Name);
-			Type = sctx.GetXamlType (xtn);
+        public void Parse ()
+        {
+            if (!Read('{'))
+                throw Error ("Invalid markup extension attribute. It should begin with '{{', but was {0}", value);
+            Name = ReadUntil (' ', true);
+            XamlTypeName xtn;
+            if (!XamlTypeName.TryParse (Name, nsResolver, out xtn))
+                throw Error ("Failed to parse type name '{0}'", Name);
+            Type = sctx.GetXamlType (xtn);
 
-			ParseArgument();
-			if (!Read('}'))
-				throw Error ("Expected '}}' in the markup extension attribute: '{0}'", value);
-		}
+            ParseArgument();
+            if (!Read('}'))
+                throw Error ("Expected '}}' in the markup extension attribute: '{0}'", value);
+        }
 
-		static Exception Error (string format, params object[] args)
-		{
-			return new XamlParseException (string.Format (format, args));
-		}
-	}
+        static Exception Error (string format, params object[] args)
+        {
+            return new XamlParseException (string.Format (format, args));
+        }
+    }
 }

--- a/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
@@ -30,311 +30,311 @@ using System.Text;
 
 namespace Portable.Xaml
 {
-    internal class ParsedMarkupExtensionInfo
-    {
-        Dictionary<XamlMember,object> args = new Dictionary<XamlMember,object> ();
-        IXamlNamespaceResolver nsResolver;
-        XamlSchemaContext sctx;
+	internal class ParsedMarkupExtensionInfo
+	{
+		Dictionary<XamlMember,object> args = new Dictionary<XamlMember,object> ();
+		IXamlNamespaceResolver nsResolver;
+		XamlSchemaContext sctx;
 
-        string value;
-        int index;
-        List<object> positionalParameters;
-        XamlMember member;
+		string value;
+		int index;
+		List<object> positionalParameters;
+		XamlMember member;
 
-        public string Name { get; set; }
-        public XamlType Type { get; set; }
+		public string Name { get; set; }
+		public XamlType Type { get; set; }
 
-        public Dictionary<XamlMember,object> Arguments
-        {
-            get { return args; }
-        }
+		public Dictionary<XamlMember,object> Arguments
+		{
+			get { return args; }
+		}
 
 
-        public ParsedMarkupExtensionInfo(string value, IXamlNamespaceResolver nsResolver, XamlSchemaContext sctx)
-        {
-            if (value == null)
-                throw new ArgumentNullException ("value");
-            this.value = value;
-            this.nsResolver = nsResolver;
-            this.sctx = sctx;
-        }
+		public ParsedMarkupExtensionInfo(string value, IXamlNamespaceResolver nsResolver, XamlSchemaContext sctx)
+		{
+			if (value == null)
+				throw new ArgumentNullException ("value");
+			this.value = value;
+			this.nsResolver = nsResolver;
+			this.sctx = sctx;
+		}
 
-        public ParsedMarkupExtensionInfo()
-        {
-        }
+		public ParsedMarkupExtensionInfo()
+		{
+		}
 
-        public ParsedMarkupExtensionInfo(ParsedMarkupExtensionInfo info)
-        {
-            this.value = info.value;
-            this.index = info.index;
-            this.nsResolver = info.nsResolver;
-            this.sctx = info.sctx;
-        }
+		public ParsedMarkupExtensionInfo(ParsedMarkupExtensionInfo info)
+		{
+			this.value = info.value;
+			this.index = info.index;
+			this.nsResolver = info.nsResolver;
+			this.sctx = info.sctx;
+		}
 
-        string ReadRest()
-        {
-            var endidx = value.IndexOf ('}', index);
-            string val;
-            if (endidx >= 0)
-            {
-                val = value.Substring(index, endidx - index);
-                index = endidx;
-            }
-            else
-            {
-                val = value.Substring(index);
-                index = value.Length;
-            }
-            return val;
-        }
+		string ReadRest()
+		{
+			var endidx = value.IndexOf ('}', index);
+			string val;
+			if (endidx >= 0)
+			{
+				val = value.Substring(index, endidx - index);
+				index = endidx;
+			}
+			else
+			{
+				val = value.Substring(index);
+				index = value.Length;
+			}
+			return val;
+		}
 
-        string ReadUntil (char ch, bool readToEnd = false, bool skip = true, char? escape = null)
-        {
-            return ReadUntil (new [] { ch }, readToEnd, skip, escape);
-        }
+		string ReadUntil (char ch, bool readToEnd = false, bool skip = true, char? escape = null)
+		{
+			return ReadUntil (new [] { ch }, readToEnd, skip, escape);
+		}
 
-        string ReadUntil (char[] ch, bool readToEnd = false, bool skip = true, char? escape = null)
-        {
-            var endidx = IndexOfAnyEscaped (new char[] { '}' }, value, escape, index);
-            var idx = IndexOfAnyEscaped (ch, value, escape, index);
-            string val = null;
-            if (idx >= 0 && idx <= endidx)
-            {
-                val = SubstringWithEscape (value, index, idx - index, escape);
-                index = skip ? idx + 1 : idx;
-            }
-            else if (readToEnd)
-            {
-                if (endidx >= 0)
-                    val = SubstringWithEscape (value, index, endidx - index, escape);
-                else
-                    val = SubstringWithEscape (value, index, escape);
-                index = endidx == -1 ? value.Length : endidx;
-            }
+		string ReadUntil (char[] ch, bool readToEnd = false, bool skip = true, char? escape = null)
+		{
+			var endidx = IndexOfAnyEscaped (new char[] { '}' }, value, escape, index);
+			var idx = IndexOfAnyEscaped (ch, value, escape, index);
+			string val = null;
+			if (idx >= 0 && idx <= endidx)
+			{
+				val = SubstringWithEscape (value, index, idx - index, escape);
+				index = skip ? idx + 1 : idx;
+			}
+			else if (readToEnd)
+			{
+				if (endidx >= 0)
+					val = SubstringWithEscape (value, index, endidx - index, escape);
+				else
+					val = SubstringWithEscape (value, index, escape);
+				index = endidx == -1 ? value.Length : endidx;
+			}
 
-            return val;
-        }
+			return val;
+		}
 
-        string SubstringWithEscape (string s, int startIndex, char? escape)
-        {
-            return SubstringWithEscape (s, startIndex, s.Length - startIndex, escape);
-        }
+		string SubstringWithEscape (string s, int startIndex, char? escape)
+		{
+			return SubstringWithEscape (s, startIndex, s.Length - startIndex, escape);
+		}
 
-        string SubstringWithEscape (string s, int startIndex, int numCharacters, char? escape)
-        {
-            // If we aren't even using escapes, use the faster method
-            if (escape == null)
-                return s.Substring (startIndex, numCharacters);
+		string SubstringWithEscape (string s, int startIndex, int numCharacters, char? escape)
+		{
+			// If we aren't even using escapes, use the faster method
+			if (escape == null)
+				return s.Substring (startIndex, numCharacters);
 
-            int idx = s.IndexOf (escape.Value, startIndex, numCharacters);
+			int idx = s.IndexOf (escape.Value, startIndex, numCharacters);
 
-            // If the string contains no escape characters, use the faster method
-            if (idx < 0 || idx >= startIndex + numCharacters)
-                return s.Substring (startIndex, numCharacters);
+			// If the string contains no escape characters, use the faster method
+			if (idx < 0 || idx >= startIndex + numCharacters)
+				return s.Substring (startIndex, numCharacters);
 
-            StringBuilder sb = new StringBuilder (s.Length);
-            while (idx >= 0 && idx < startIndex + numCharacters)
-            {
-                if (idx - startIndex > 0)
-                    sb.Append (s.Substring (startIndex, idx - startIndex));
-                if (idx + 1 < s.Length)
-                    sb.Append (s[idx + 1]);
-                numCharacters -= (idx - startIndex + 2);
-                startIndex = idx + 2;
-                idx = s.IndexOf (escape.Value, startIndex, numCharacters);
-            }
+			StringBuilder sb = new StringBuilder (s.Length);
+			while (idx >= 0 && idx < startIndex + numCharacters)
+			{
+				if (idx - startIndex > 0)
+					sb.Append (s.Substring (startIndex, idx - startIndex));
+				if (idx + 1 < s.Length)
+					sb.Append (s[idx + 1]);
+				numCharacters -= (idx - startIndex + 2);
+				startIndex = idx + 2;
+				idx = s.IndexOf (escape.Value, startIndex, numCharacters);
+			}
 
-            if (idx > 0)
-                sb.Append (s.Substring (startIndex, numCharacters));
+			if (idx > 0)
+				sb.Append (s.Substring (startIndex, numCharacters));
 
-            return sb.ToString ();
-        }
+			return sb.ToString ();
+		}
 
-        int IndexOfAnyEscaped (char[] ch, string value, char? escape, int startIdx)
-        {
-            if (escape == null)
-                return value.IndexOfAny(ch, startIdx);
+		int IndexOfAnyEscaped (char[] ch, string value, char? escape, int startIdx)
+		{
+			if (escape == null)
+				return value.IndexOfAny(ch, startIdx);
 
-            int idx = 0, nextStart = startIdx;
+			int idx = 0, nextStart = startIdx;
 
-            do
-            {
-                idx = ch.Length == 1 ? value.IndexOf (ch[0], nextStart) : value.IndexOfAny (ch, nextStart);
-                nextStart = idx + 1;
+			do
+			{
+				idx = ch.Length == 1 ? value.IndexOf (ch[0], nextStart) : value.IndexOfAny (ch, nextStart);
+				nextStart = idx + 1;
 
-                // If no good match, return; otherwise, check for escape characters
-                if (idx < 0 || idx >= value.Length)
-                    break;
-                else
-                {
-                    // We need to handle repetitions. If there are an odd number of escape characters behind us, we
-                    // are escaped; if an even number, we aren't escaped.
-                    int numEscapes = 0;
-                    for (int i = idx - 1; i >=0 && value [i] == escape.Value; i--)
-                    {
-                        ++numEscapes;
-                    }
+				// If no good match, return; otherwise, check for escape characters
+				if (idx < 0 || idx >= value.Length)
+					break;
+				else
+				{
+					// We need to handle repetitions. If there are an odd number of escape characters behind us, we
+					// are escaped; if an even number, we aren't escaped.
+					int numEscapes = 0;
+					for (int i = idx - 1; i >=0 && value [i] == escape.Value; i--)
+					{
+						++numEscapes;
+					}
 
-                    if (numEscapes % 2 == 0)
-                        break;
-                }
-            }
-            while (true);
+					if (numEscapes % 2 == 0)
+						break;
+				}
+			}
+			while (true);
 
-            return idx;
-        }
+			return idx;
+		}
 
-        void ReadWhitespace ()
-        {
-            while (index < value.Length && char.IsWhiteSpace (value [index])) {
-                index++;
-            }
-        }
+		void ReadWhitespace ()
+		{
+			while (index < value.Length && char.IsWhiteSpace (value [index])) {
+				index++;
+			}
+		}
 
-        bool ReadWhitespaceUntil (char ch)
-        {
-            var old = index;
-            while (index < value.Length && char.IsWhiteSpace (value [index])) {
-                index++;
-            }
-            if (Current == ch)
-            {
-                index++;
-                return true;
-            }
-            index = old;
-            return false;
-        }
+		bool ReadWhitespaceUntil (char ch)
+		{
+			var old = index;
+			while (index < value.Length && char.IsWhiteSpace (value [index])) {
+				index++;
+			}
+			if (Current == ch)
+			{
+				index++;
+				return true;
+			}
+			index = old;
+			return false;
+		}
 
-        bool Read(char ch)
-        {
-            if (Current == ch) {
-                index++;
-                return true;
-            }
-            return false;
-        }
+		bool Read(char ch)
+		{
+			if (Current == ch) {
+				index++;
+				return true;
+			}
+			return false;
+		}
 
-        void AddPositionalParameter (object value)
-        {
-            if (positionalParameters == null) {
-                positionalParameters = new List<object> ();
-                if (Arguments.Count > 0)
-                {
-                    // positional parameters can't come after non-positional parameters
-                    throw Error("Unexpected positional parameter in expression '{0}'", this.value);
-                }
-                Arguments.Add (XamlLanguage.PositionalParameters, positionalParameters);
-            }
-            positionalParameters.Add (value);
-        }
+		void AddPositionalParameter (object value)
+		{
+			if (positionalParameters == null) {
+				positionalParameters = new List<object> ();
+				if (Arguments.Count > 0)
+				{
+					// positional parameters can't come after non-positional parameters
+					throw Error("Unexpected positional parameter in expression '{0}'", this.value);
+				}
+				Arguments.Add (XamlLanguage.PositionalParameters, positionalParameters);
+			}
+			positionalParameters.Add (value);
+		}
 
-        object ParseEscapedValue()
-        {
-            switch (Current)
-            {
-                case '{':
-                    var markup = ReadMarkup();
-                    if (markup != null)
-                    {
-                        ReadUntil(',', true, escape: '\\');
-                        return markup;
-                    }
-                    break;
-                case '\'':
-                case '"':
-                    var idx = index;
-                    var endch = Current;
-                    index++;
-                    var val = ReadUntil(endch, escape: '\\');
-                    if (val != null)
-                    {
-                        ReadUntil(',', true, escape: '\\');
-                        return val;
-                    }
-                    index = idx;
-                    break;
-            }
-            return null;
-        }
+		object ParseEscapedValue()
+		{
+			switch (Current)
+			{
+				case '{':
+					var markup = ReadMarkup();
+					if (markup != null)
+					{
+						ReadUntil(',', true, escape: '\\');
+						return markup;
+					}
+					break;
+				case '\'':
+				case '"':
+					var idx = index;
+					var endch = Current;
+					index++;
+					var val = ReadUntil(endch, escape: '\\');
+					if (val != null)
+					{
+						ReadUntil(',', true, escape: '\\');
+						return val;
+					}
+					index = idx;
+					break;
+			}
+			return null;
+		}
 
-        bool ParseArgument ()
-        {
-            ReadWhitespace();
-            var escapedValue = ParseEscapedValue ();
-            if (escapedValue != null)
-            {
-                AddPositionalParameter(escapedValue);
-                ParseArgument();
-                return true;
-            }
+		bool ParseArgument ()
+		{
+			ReadWhitespace();
+			var escapedValue = ParseEscapedValue ();
+			if (escapedValue != null)
+			{
+				AddPositionalParameter(escapedValue);
+				ParseArgument();
+				return true;
+			}
 
-            var name = ReadUntil(new [] { '=', ' ', ',' }, readToEnd: true, skip: false, escape: '\\');
-            if (string.IsNullOrEmpty(name))
-                return false;
-            if (!ReadWhitespaceUntil('='))
-            {
-                AddPositionalParameter(name + ReadUntil(',', true, escape: '\\').TrimEnd());
-                ParseArgument();
-                return true;
-            }
-            member = Type.GetMember (name) ?? new XamlMember(name, Type, false);
-            ReadWhitespace ();
-            ParseValue ();
-            return true;
-        }
+			var name = ReadUntil(new [] { '=', ' ', ',' }, readToEnd: true, skip: false, escape: '\\');
+			if (string.IsNullOrEmpty(name))
+				return false;
+			if (!ReadWhitespaceUntil('='))
+			{
+				AddPositionalParameter(name + ReadUntil(',', true, escape: '\\').TrimEnd());
+				ParseArgument();
+				return true;
+			}
+			member = Type.GetMember (name) ?? new XamlMember(name, Type, false);
+			ReadWhitespace ();
+			ParseValue ();
+			return true;
+		}
 
-        char Current { get { return index < value.Length ? value [index] : unchecked((char)-1); } }
+		char Current { get { return index < value.Length ? value [index] : unchecked((char)-1); } }
 
-        bool Finished { get { return index >= value.Length; } }
+		bool Finished { get { return index >= value.Length; } }
 
-        ParsedMarkupExtensionInfo ReadMarkup()
-        {
-            var info = new ParsedMarkupExtensionInfo (this);
-            try {
-                info.Parse ();
-                index = info.index;
-                return info;
-            } catch {
-            }
-            return null;
-        }
+		ParsedMarkupExtensionInfo ReadMarkup()
+		{
+			var info = new ParsedMarkupExtensionInfo (this);
+			try {
+				info.Parse ();
+				index = info.index;
+				return info;
+			} catch {
+			}
+			return null;
+		}
 
-        void ParseValue()
-        {
-            var escapedValue = ParseEscapedValue ();
-            if (escapedValue != null) {
-                Arguments.Add (member, escapedValue);
-                ParseArgument();
-                return;
-            }
+		void ParseValue()
+		{
+			var escapedValue = ParseEscapedValue ();
+			if (escapedValue != null) {
+				Arguments.Add (member, escapedValue);
+				ParseArgument();
+				return;
+			}
 
-            var val = ReadUntil(',', true, escape: '\\');
+			var val = ReadUntil(',', true, escape: '\\');
 			val = val.Trim ();
-            Arguments.Add (member, val);
-            if (!ParseArgument()) {
-                Arguments [member] = val + ReadRest ();
-            }
-        }
+			Arguments.Add (member, val);
+			if (!ParseArgument()) {
+				Arguments [member] = val + ReadRest ();
+			}
+		}
 
-        public void Parse ()
-        {
-            if (!Read('{'))
-                throw Error ("Invalid markup extension attribute. It should begin with '{{', but was {0}", value);
-            Name = ReadUntil (' ', true);
-            XamlTypeName xtn;
-            if (!XamlTypeName.TryParse (Name, nsResolver, out xtn))
-                throw Error ("Failed to parse type name '{0}'", Name);
-            Type = sctx.GetXamlType (xtn);
+		public void Parse ()
+		{
+			if (!Read('{'))
+				throw Error ("Invalid markup extension attribute. It should begin with '{{', but was {0}", value);
+			Name = ReadUntil (' ', true);
+			XamlTypeName xtn;
+			if (!XamlTypeName.TryParse (Name, nsResolver, out xtn))
+				throw Error ("Failed to parse type name '{0}'", Name);
+			Type = sctx.GetXamlType (xtn);
 
-            ParseArgument();
-            if (!Read('}'))
-                throw Error ("Expected '}}' in the markup extension attribute: '{0}'", value);
-        }
+			ParseArgument();
+			if (!Read('}'))
+				throw Error ("Expected '}}' in the markup extension attribute: '{0}'", value);
+		}
 
-        static Exception Error (string format, params object[] args)
-        {
-            return new XamlParseException (string.Format (format, args));
-        }
-    }
+		static Exception Error (string format, params object[] args)
+		{
+			return new XamlParseException (string.Format (format, args));
+		}
+	}
 }

--- a/src/Test/System.Xaml/XamlReaderTestBase.cs
+++ b/src/Test/System.Xaml/XamlReaderTestBase.cs
@@ -1325,7 +1325,17 @@ namespace MonoTests.Portable.Xaml
 			Assert.IsTrue(r.IsEof, "#3-2");
 		}
 
-		protected void Read_CustomExtensionWithPositionalAndNamed(XamlReader r)
+        // cf. https://msdn.microsoft.com/en-us/library/ee200269.aspx
+        //     "If the next character is a "\" (Unicode code point 005C), consume that "\" without adding 
+        //     it to the text value, then consume the following character and append that to the value."
+        protected void Load_CustomExtensionWithEscapeChars(XamlReader r)
+        {
+            ValueWrapper o = XamlServices.Load(r) as ValueWrapper;
+            Assert.IsNotNull(o, "Null, or not a ValueWrapper");
+            Assert.AreEqual("Quoted string: 'test'; Embedded braces: {test}; Two Backslashes: \\\\", o.StringValue, "Escape character not parsed properly");
+        }
+
+        protected void Read_CustomExtensionWithPositionalAndNamed(XamlReader r)
 		{
 			r.Read(); // ns
 			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, r.NodeType, "#1");

--- a/src/Test/System.Xaml/XamlReaderTestBase.cs
+++ b/src/Test/System.Xaml/XamlReaderTestBase.cs
@@ -1332,7 +1332,7 @@ namespace MonoTests.Portable.Xaml
         {
             ValueWrapper o = XamlServices.Load(r) as ValueWrapper;
             Assert.IsNotNull(o, "Null, or not a ValueWrapper");
-            Assert.AreEqual("Quoted string: 'test'; Embedded braces: {test}; Two Backslashes: \\\\", o.StringValue, "Escape character not parsed properly");
+            Assert.AreEqual("Quoted string: 'test'; Embedded braces: {test}; Two Backslashes: \\\\ (test after last escape)", o.StringValue, "Escape character not parsed properly");
         }
 
         protected void Read_CustomExtensionWithPositionalAndNamed(XamlReader r)

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -516,7 +516,14 @@ namespace MonoTests.Portable.Xaml
 			Read_CustomExtensionWithCommasInPositionalValue(r);
 		}
 
-		[Test]
+        [Test]
+        public void Load_CustomExtensionWithEscapeChars()
+        {
+            var r = GetReader("CustomExtensionWithEscapeChars.xml");
+            Load_CustomExtensionWithEscapeChars(r);
+        }
+
+        [Test]
 		public void Read_CustomExtensionWithPositionalAndNamed()
 		{
 			var r = GetReader("CustomExtensionWithPositionalAndNamed.xml");

--- a/src/Test/XmlFiles/CustomExtensionWithEscapeChars.xml
+++ b/src/Test/XmlFiles/CustomExtensionWithEscapeChars.xml
@@ -1,0 +1,4 @@
+<ValueWrapper 
+	StringValue="{MyExtension6 'Quoted string: \'test\'; Embedded braces: {test\}; Two Backslashes: \\\\'}" 
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0" />

--- a/src/Test/XmlFiles/CustomExtensionWithEscapeChars.xml
+++ b/src/Test/XmlFiles/CustomExtensionWithEscapeChars.xml
@@ -1,4 +1,4 @@
 <ValueWrapper 
-	StringValue="{MyExtension6 'Quoted string: \'test\'; Embedded braces: {test\}; Two Backslashes: \\\\'}" 
+	StringValue="{MyExtension6 'Quoted string: \'test\'; Embedded braces: {test\}; Two Backslashes: \\\\ (test after last escape)'}" 
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0" />


### PR DESCRIPTION
### Bug: Escape characters not supported in markup extensions

Per [the XAML spec](https://msdn.microsoft.com/en-us/library/ee200269.aspx), markup extension parsing should respect the backslash as an escape character; any character following a backslash should be consumed as-is and not used to terminate the extension. However, Portable.Xaml (and presumably the underlying Mono version) does not conform to this aspect of the spec.

For instance, given the following:

```
{MyExtension6 'Quoted string: \'test\'; Embedded braces: {test\}; Two Backslashes: \\\\'}
```

...the parser should populate the first positional property with:

```
Quoted string test: 'test'; Embedded braces: {test}; Two Backslashes: \\
```

The existing code truncates the value, because it does a naïve search for the first single quote, treating the escape character as normal text:

```
Quoted string test: \
```

A similar bug affects closing curly braces. This pull request resolves the bug by adding escape character support to `ParsedMarkupExtensionInfo.cs`. This prevents quoted strings passed to markup extensions from being prematurely terminated due to escaped subquotes or escaped right-braces. It removes escape characters from output where applicable and allows escaping of the backslash character itself as well.

Since no existing tests in the test suite covered the broken use cases, I provided new test `Load_CustomExtensionWithEscapeCharacters()` in `XamlXmlReader.cs`, which makes use of the new `CustomExtensionWithEscapeChars.xml` test file. Note that the nature of the test (actually inflating a whole object) differs from the other tests in the file, which mainly look at the XAML nodes read by the reader. This is insufficient, as the error doesn't happen at this stage but when the markup extension is actually parsed. I considered creating a separate file with those, but the test is parallel to the other markup extension tests adjacent to where I inserted the new one.

All the same tests pass as when I cloned the solution, so I assume this did not introduce any other functional changes in the codebase.

Again, this is my first pull request, so any feedback is welcome!
