### PR TITLE
Fix getting ambient values using the GetAllAmbientValues(XamlType[]) api

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
@@ -277,7 +277,7 @@ namespace Portable.Xaml
 
 		public IEnumerable<object> GetAllAmbientValues(params XamlType[] types)
 		{
-			return GetAllAmbientValues(null, false, types);
+			return GetAllAmbientValues (null, false, types).Select(r => r.Value);
 		}
 
 		public IEnumerable<AmbientPropertyValue> GetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, params XamlMember[] properties)


### PR DESCRIPTION
Should return the values of each of the ambient values, not the AmbientPropertyValue instance.

Fixes #26 