### PR TITLE
More performance enhancements!

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ Contributors are more than welcome! Ideally this library can become well support
 
 What about performance you ask? Portable.Xaml can actually be faster than .NET's System.Xaml in most cases, especially when loading xaml.
 
-Portable.Xaml's performance has also been drastically improved over mono's initial implementation, which used to be many times slower than .NET.
+Portable.Xaml's performance has also been drastically improved over mono's initial implementation by 11x loading, and 28x saving.
 
 Here's some results using [BenchmarkDotNet](http://benchmarkdotnet.org):
 
 ### Load
-Method |          Mean |     StdDev | Scaled | Scaled-StdDev | Allocated |------------- |-------------- |----------- |------- |-------------- |---------- | PortableXaml |   782.1410 us |  7.4904 us |   1.00 |          0.00 |  76.77 kB |   SystemXaml | 1,376.8630 us | 11.5132 us |   1.76 |          0.02 | 155.19 kB |
-   
+Method |          Mean |     StdDev | Scaled | Scaled-StdDev | Allocated |-------------------- |-------------- |----------- |------- |-------------- |---------- |        PortableXaml |   726.6193 us | 28.2493 us |   1.00 |          0.00 |  72.23 kB |          SystemXaml | 1,330.3755 us | 31.5314 us |   1.83 |          0.08 | 155.19 kB | PortableXamlNoCache | 1,598.9083 us | 22.4152 us |   2.20 |          0.09 | 129.89 kB |   SystemXamlNoCache | 1,899.0161 us | 90.5633 us |   2.62 |          0.16 | 187.14 kB |
+
 ### Save
-Method |        Mean |     StdDev | Scaled | Scaled-StdDev |  Gen 0 | Allocated |------------- |------------ |----------- |------- |-------------- |------- |---------- | PortableXaml | 859.9563 us | 10.3759 us |   1.00 |          0.00 | 5.7292 | 180.25 kB |   SystemXaml | 914.7401 us | 14.3295 us |   1.06 |          0.02 |      - | 120.03 kB |
+Method |          Mean |     StdDev | Scaled | Scaled-StdDev |   Gen 0 | Allocated |-------------------- |-------------- |----------- |------- |-------------- |-------- |---------- |        PortableXaml |   813.9052 us | 11.2787 us |   1.00 |          0.00 |       - | 146.18 kB |          SystemXaml |   874.2129 us | 15.8162 us |   1.07 |          0.02 |       - | 120.03 kB | PortableXamlNoCache | 1,588.3347 us |  9.7873 us |   1.95 |          0.03 | 15.6250 | 197.46 kB |   SystemXamlNoCache | 1,187.0039 us | 13.3269 us |   1.46 |          0.03 |       - | 142.01 kB |
 
 ## License
 

--- a/src/Portable.Xaml.Benchmark/LoadBenchmark.cs
+++ b/src/Portable.Xaml.Benchmark/LoadBenchmark.cs
@@ -4,14 +4,16 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using BenchmarkDotNet.Attributes.Columns;
+using System.Diagnostics;
 
 namespace Portable.Xaml.Benchmark
 {
-	public abstract class LoadBenchmark : XamlBenchmark
+	[Config(typeof(Config))]
+	public abstract class LoadBenchmark : IXamlBenchmark
 	{
 		public abstract string TestName { get; }
 
-		protected Stream GetStream() => typeof(XamlBenchmark).Assembly.GetManifestResourceStream("Portable.Xaml.Benchmark." + TestName);
+		protected Stream GetStream() => typeof(IXamlBenchmark).Assembly.GetManifestResourceStream("Portable.Xaml.Benchmark." + TestName);
 
 		Portable.Xaml.XamlSchemaContext pxc;
 		[Benchmark(Baseline = true)]
@@ -29,6 +31,20 @@ namespace Portable.Xaml.Benchmark
 			sxc = sxc ?? (sxc = new System.Xaml.XamlSchemaContext());
 			using (var stream = GetStream())
 				System.Xaml.XamlServices.Load(new System.Xaml.XamlXmlReader(stream, sxc));
+		}
+
+		[Benchmark]
+		public void PortableXamlNoCache()
+		{
+			using (var stream = GetStream())
+				Portable.Xaml.XamlServices.Load(stream);
+		}
+
+		[Benchmark]
+		public void SystemXamlNoCache()
+		{
+			using (var stream = GetStream())
+				System.Xaml.XamlServices.Load(stream);
 		}
 	}
 }

--- a/src/Portable.Xaml.Benchmark/Program.cs
+++ b/src/Portable.Xaml.Benchmark/Program.cs
@@ -3,17 +3,37 @@ using BenchmarkDotNet.Attributes;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Running;
 
 namespace Portable.Xaml.Benchmark
 {
+	class Config : ManualConfig
+	{
+		public Config()
+		{
+			/* doesn't work yet, still runs twice as of BenchmarkDotNet 0.10.1
+			Add(Job.Dry
+				.With(RunStrategy.ColdStart)
+				.WithLaunchCount(4)
+				.WithId("ColdStart")
+				);
+			*/
+			
+			Add(Job.Default);
+		}
+	}
+
 	class MainClass
 	{
-		public static void Main (string [] args)
+		public static void Main(string[] args)
 		{
 			/**  Uncomment to test using performance profiler *
 			
-			var benchmark = new LoadSimpleBenchmark();
-			//var benchmark = new LoadComplexBenchmark();
+			//var benchmark = new LoadSimpleBenchmark();
+			var benchmark = new LoadComplexBenchmark();
 			//var benchmark = new SaveSimpleBenchmark();
 			//var benchmark = new SaveComplexBenchmark();
 			for (int i = 0; i < 10000; i++)
@@ -23,15 +43,15 @@ namespace Portable.Xaml.Benchmark
 			}
 			return;
 			/**/
-			
+
 			// BenchmarkSwitcher doesn't automatically exclude abstract benchmark classes
-			var types = typeof (MainClass)
+			var types = typeof(MainClass)
 				.Assembly
-				.GetExportedTypes ()
-				.Where (r => typeof (XamlBenchmark).IsAssignableFrom (r) && !r.IsAbstract);
-			
-			var switcher = new BenchmarkDotNet.Running.BenchmarkSwitcher (types.ToArray());
-			switcher.Run (args);
+				.GetExportedTypes()
+				.Where(r => typeof(IXamlBenchmark).IsAssignableFrom(r) && !r.IsAbstract);
+
+			var switcher = new BenchmarkSwitcher(types.ToArray());
+			switcher.Run(args);
 		}
 	}
 }

--- a/src/Portable.Xaml.Benchmark/SaveBenchmark.cs
+++ b/src/Portable.Xaml.Benchmark/SaveBenchmark.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes.Columns;
 
 namespace Portable.Xaml.Benchmark
 {
-	public abstract class SaveBenchmark : XamlBenchmark
+	public abstract class SaveBenchmark : IXamlBenchmark
 	{
 		public abstract object Instance { get; }
 
@@ -27,6 +27,20 @@ namespace Portable.Xaml.Benchmark
 			sxc = sxc ?? (sxc = new System.Xaml.XamlSchemaContext());
 			using (var stream = new MemoryStream())
 				System.Xaml.XamlServices.Save(new System.Xaml.XamlXmlWriter(stream, sxc), Instance);
+		}
+
+		[Benchmark]
+		public void PortableXamlNoCache()
+		{
+			using (var stream = new MemoryStream())
+				Portable.Xaml.XamlServices.Save(stream, Instance);
+		}
+
+		[Benchmark]
+		public void SystemXamlNoCache()
+		{
+			using (var stream = new MemoryStream())
+				System.Xaml.XamlServices.Save(stream, Instance);
 		}
 	}
 }

--- a/src/Portable.Xaml.Benchmark/XamlBenchmark.cs
+++ b/src/Portable.Xaml.Benchmark/XamlBenchmark.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Portable.Xaml.Benchmark
 {
-	public abstract class XamlBenchmark
+	public interface IXamlBenchmark
 	{
 	}
 }

--- a/src/Portable.Xaml/Portable.Xaml-pcl136.csproj
+++ b/src/Portable.Xaml/Portable.Xaml-pcl136.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\artifacts\pcl136\Debug</OutputPath>
-    <DefineConstants>DEBUG;PCL;PCL136;USE_EXPRESSIONS</DefineConstants>
+    <DefineConstants>DEBUG;PCL;PCL136</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -30,7 +30,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <DefineConstants>PCL;PCL136;USE_EXPRESSIONS</DefineConstants>
+    <DefineConstants>PCL;PCL136</DefineConstants>
   </PropertyGroup>
   <Import Project="..\Shared\Common.props" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />

--- a/src/Portable.Xaml/Portable.Xaml-pcl259.csproj
+++ b/src/Portable.Xaml/Portable.Xaml-pcl259.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\artifacts\pcl259\Debug</OutputPath>
-    <DefineConstants>DEBUG;PCL;MONO;PCL259;USE_EXPRESSIONS</DefineConstants>
+    <DefineConstants>DEBUG;PCL;MONO;PCL259</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -30,7 +30,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <DefineConstants>PCL;MONO;PCL259;USE_EXPRESSIONS</DefineConstants>
+    <DefineConstants>PCL;MONO;PCL259</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/src/Portable.Xaml/Portable.Xaml.Schema/XamlTypeInvoker.cs
+++ b/src/Portable.Xaml/Portable.Xaml.Schema/XamlTypeInvoker.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Portable.Xaml.Markup;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Portable.Xaml.Schema
 {
@@ -43,26 +44,41 @@ namespace Portable.Xaml.Schema
 		{
 			if (type == null)
 				throw new ArgumentNullException ("type");
-			this.type = type;
+			Type = type;
 		}
 		
-		XamlType type;
-		Type mutableType;
-		MethodInfo createImmutableFromMutable;
-		Dictionary<Tuple<Type, Type, Type>, MethodInfo> add_method_cache = new Dictionary<Tuple<Type, Type, Type>, MethodInfo>();
+		Dictionary<object, object> cache;
+
+		static object s_CreateImmutableFromMutableKey = new object();
+		static object s_MutableTypeKey = new object();
+
+		bool TryGetCache<T>(object key, out T value)
+			where T: class
+		{
+			if (cache == null)
+				cache = new Dictionary<object, object>();
+			object obj;
+			if (!cache.TryGetValue(key, out obj))
+			{
+				value = default(T);
+				return false;
+			}
+			value = obj as T;
+			return !ReferenceEquals(value, null);
+		}
 
 		[EnhancedXaml]
-		protected XamlType Type => type;
+		protected XamlType Type { get; }
 
 		void ThrowIfUnknown ()
 		{
-			if (type == null || type.UnderlyingType == null)
-				throw new NotSupportedException (string.Format ("Current operation is valid only when the underlying type on a XamlType is known, but it is unknown for '{0}'", type));
+			if (Type == null || Type.UnderlyingType == null)
+				throw new NotSupportedException (string.Format ("Current operation is valid only when the underlying type on a XamlType is known, but it is unknown for '{0}'", Type));
 		}
 
-		public EventHandler<XamlSetMarkupExtensionEventArgs> SetMarkupExtensionHandler => type?.SetMarkupExtensionHandler;
+		public EventHandler<XamlSetMarkupExtensionEventArgs> SetMarkupExtensionHandler => Type?.SetMarkupExtensionHandler;
 
-		public EventHandler<XamlSetTypeConverterEventArgs> SetTypeConverterHandler => type?.SetTypeConverterHandler;
+		public EventHandler<XamlSetTypeConverterEventArgs> SetTypeConverterHandler => Type?.SetTypeConverterHandler;
 
 
 		public virtual void AddToCollection (object instance, object item)
@@ -74,43 +90,83 @@ namespace Portable.Xaml.Schema
 
 			var collectionType = instance.GetType ();
 			var itemType = item.GetType();
-			var key = Tuple.Create(collectionType, itemType, (Type)null);
+			var key = Tuple.Create(collectionType, itemType);
 
-            MethodInfo mi = null;
-			if (!add_method_cache.TryGetValue(key, out mi))
+			var mode = Type?.SchemaContext.InvokerOptions ?? XamlInvokerOptions.None;
+			if (mode.HasFlag(XamlInvokerOptions.Compile))
 			{
+				Action<object, object> addDelegate;
+				if (TryGetCache(key, out addDelegate))
+				{
+					addDelegate(instance, item);
+					return;
+				}
+
+				MethodInfo mi = LookupAddCollectionMethod(Type, collectionType, itemType);
+				if (mi == null)
+					throw new InvalidOperationException($"The collection type '{collectionType}' does not have 'Add' method");
+
+				if (mode.HasFlag(XamlInvokerOptions.DeferCompile))
+				{
+					addDelegate = (i, v) => mi.Invoke(i, new object[] { v });
+					Task.Factory.StartNew(() => cache[key] = addDelegate = mi.BuildCallExpression());
+				}
+				else
+				{
+					addDelegate = mi.BuildCallExpression();
+				}
+				cache[key] = addDelegate;
+				addDelegate(instance, item);
+			}
+			else
+			{
+				MethodInfo mi;
+				if (TryGetCache(key, out mi))
+				{
+					mi.Invoke(instance, new object[] { item });
+					return;
+				}
+
+				mi = LookupAddCollectionMethod(Type, collectionType, itemType);
+				if (mi == null)
+					throw new InvalidOperationException($"The collection type '{collectionType}' does not have 'Add' method");
 				// FIXME: this method lookup should be mostly based on GetAddMethod(). At least iface method lookup must be done there.
-				if (type != null && type.UnderlyingType != null)
-				{
-					var xct = type.SchemaContext.GetXamlType(collectionType);
-					if (!xct.IsCollection) // not sure why this check is done only when UnderlyingType exists...
-						throw new NotSupportedException(String.Format("Non-collection type '{0}' does not support this operation", xct));
-					if (collectionType.GetTypeInfo().IsAssignableFrom(type.UnderlyingType.GetTypeInfo()))
-						mi = GetAddMethod(type.SchemaContext.GetXamlType(itemType));
-				}
+				cache[key] = mi;
+				mi.Invoke(instance, new object[] { item });
+			}
+		}
 
-				if (mi == null)
-				{
-					if (collectionType.GetTypeInfo().IsGenericType)
-					{
-						mi = collectionType.GetRuntimeMethod("Add", collectionType.GetTypeInfo().GetGenericArguments());
-						if (mi == null)
-							mi = LookupAddMethod(collectionType, typeof(ICollection<>).MakeGenericType(collectionType.GetTypeInfo().GetGenericArguments()));
-					}
-					else
-					{
-						mi = collectionType.GetRuntimeMethod("Add", new Type[] { typeof(object) });
-						if (mi == null)
-							mi = LookupAddMethod(collectionType, typeof(IList));
-					}
-				}
+		MethodInfo LookupAddCollectionMethod(XamlType type, Type collectionType, Type itemType)
+		{
+			// FIXME: this method lookup should be mostly based on GetAddMethod(). At least iface method lookup must be done there.
+			MethodInfo mi = null;
+			if (type != null && type.UnderlyingType != null)
+			{
+				var xct = type.SchemaContext.GetXamlType(collectionType);
+				if (!xct.IsCollection) // not sure why this check is done only when UnderlyingType exists...
+					throw new NotSupportedException(String.Format("Non-collection type '{0}' does not support this operation", xct));
+				if (collectionType.GetTypeInfo().IsAssignableFrom(type.UnderlyingType.GetTypeInfo()))
+					mi = GetAddMethod(type.SchemaContext.GetXamlType(itemType));
+			}
 
-				if (mi == null)
-					throw new InvalidOperationException(String.Format("The collection type '{0}' does not have 'Add' method", collectionType));
-				add_method_cache[key] = mi;
-            }
-			
-			mi.Invoke (instance, new object [] {item});
+			if (mi == null)
+			{
+				if (collectionType.GetTypeInfo().IsGenericType)
+				{
+					mi = collectionType.GetRuntimeMethod("Add", collectionType.GetTypeInfo().GetGenericArguments());
+					if (mi == null)
+						mi = LookupAddMethod(collectionType, typeof(ICollection<>).MakeGenericType(collectionType.GetTypeInfo().GetGenericArguments()));
+				}
+				else
+				{
+					mi = collectionType.GetRuntimeMethod("Add", new Type[] { typeof(object) });
+					if (mi == null)
+						mi = LookupAddMethod(collectionType, typeof(IList));
+				}
+			}
+
+			return mi;
+
 		}
 
 		public virtual void AddToDictionary (object instance, object key, object item)
@@ -118,30 +174,70 @@ namespace Portable.Xaml.Schema
 			if (instance == null)
 				throw new ArgumentNullException ("instance");
 
-			var t = instance.GetType ();
-			// FIXME: this likely needs similar method lookup to AddToCollection().
-			var lookupKey = Tuple.Create(t, key?.GetType(), item?.GetType());
-			MethodInfo mi = null;
-			if (!add_method_cache.TryGetValue(lookupKey, out mi))
-			{
+			var instanceType = instance.GetType ();
 
-				if (t.GetTypeInfo().IsGenericType)
+			var lookupKey = Tuple.Create(instanceType, key?.GetType(), item?.GetType());
+
+			var mode = Type?.SchemaContext.InvokerOptions ?? XamlInvokerOptions.None;
+			if (mode.HasFlag(XamlInvokerOptions.Compile))
+			{
+				Action<object, object, object> addDelegate;
+				if (TryGetCache(lookupKey, out addDelegate))
 				{
-					mi = instance.GetType().GetRuntimeMethod("Add", t.GetTypeInfo().GetGenericArguments());
-					if (mi == null)
-						mi = LookupAddMethod(t, typeof(IDictionary<,>).MakeGenericType(t.GetTypeInfo().GetGenericArguments()));
+					addDelegate(instance, key, item);
+					return;
+				}
+
+				MethodInfo mi = LookupAddDictionaryMethod(instanceType);
+				if (mi == null)
+					throw new InvalidOperationException($"The dictionary type '{instanceType}' does not have 'Add' method");
+				if (mode.HasFlag(XamlInvokerOptions.DeferCompile))
+				{
+					addDelegate = (i, k, v) => mi.Invoke(i, new object[] { k, v });
+					Task.Factory.StartNew(() => cache[key] = addDelegate = mi.BuildCall2Expression());
 				}
 				else
 				{
-					mi = instance.GetType().GetRuntimeMethod("Add", new Type[] { typeof(object), typeof(object) });
-					if (mi == null)
-						mi = LookupAddMethod(t, typeof(IDictionary));
+					addDelegate = mi.BuildCall2Expression();
 				}
-				add_method_cache[lookupKey] = mi;
+				cache[lookupKey] = addDelegate;
+				addDelegate(instance, key, item);
 			}
-			mi.Invoke (instance, new object [] {key, item});
+			else
+			{
+				MethodInfo mi;
+				if (TryGetCache(lookupKey, out mi))
+				{
+					mi.Invoke(instance, new object[] { key, item });
+					return;
+				}
+
+				mi = LookupAddDictionaryMethod(instanceType);
+				if (mi == null)
+					throw new InvalidOperationException($"The dictionary type '{instanceType}' does not have 'Add' method");
+				cache[lookupKey] = mi;
+				mi.Invoke (instance, new object [] {key, item});
+			}
 		}
-		
+
+		MethodInfo LookupAddDictionaryMethod(Type dictionaryType)
+		{
+			MethodInfo mi;
+			if (dictionaryType.GetTypeInfo().IsGenericType)
+			{
+				mi = dictionaryType.GetRuntimeMethod("Add", dictionaryType.GetTypeInfo().GetGenericArguments());
+				if (mi == null)
+					mi = LookupAddMethod(dictionaryType, typeof(IDictionary<,>).MakeGenericType(dictionaryType.GetTypeInfo().GetGenericArguments()));
+			}
+			else
+			{
+				mi = dictionaryType.GetRuntimeMethod("Add", new Type[] { typeof(object), typeof(object) });
+				if (mi == null)
+					mi = LookupAddMethod(dictionaryType, typeof(IDictionary));
+			}
+			return mi;
+		}
+
 		MethodInfo LookupAddMethod (Type ct, Type iface)
 		{
 			var map = ct.GetTypeInfo().GetRuntimeInterfaceMap(iface);
@@ -155,25 +251,27 @@ namespace Portable.Xaml.Schema
 		{
 			ThrowIfUnknown ();
 			if (arguments == null)
-				return Activator.CreateInstance(type.UnderlyingType);
+				return Activator.CreateInstance(Type.UnderlyingType);
 			else
-				return Activator.CreateInstance (type.UnderlyingType, arguments);
+				return Activator.CreateInstance (Type.UnderlyingType, arguments);
 		}
 
 		[EnhancedXaml]
 		public virtual object ToMutable(object instance)
 		{
-			if (!type.IsImmutableCollection)
+			if (!Type.IsImmutableCollection)
 				return instance;
 
+			Type mutableType;
 			// Use a List<> or Dictionary<,> to collect values for immutable collections
-			if (mutableType == null)
+			if (!TryGetCache<Type>(s_MutableTypeKey, out mutableType))
 			{
-				var typeArgs = type.UnderlyingType.GetTypeInfo().GetGenericArguments();
+				var typeArgs = Type.UnderlyingType.GetTypeInfo().GetGenericArguments();
 				var listType = typeArgs.Length == 2 ? typeof(Dictionary<,>) : typeof(List<>);
 				mutableType = listType.MakeGenericType(typeArgs);
+				cache[s_MutableTypeKey] = mutableType;
 			}
-			if (instance == null || type.UnderlyingType.GetTypeInfo().IsValueType)
+			if (instance == null || Type.UnderlyingType.GetTypeInfo().IsValueType)
 				return Activator.CreateInstance(mutableType);
 			
 			return Activator.CreateInstance(mutableType, instance);
@@ -182,35 +280,37 @@ namespace Portable.Xaml.Schema
 		[EnhancedXaml]
 		public virtual object ToImmutable(object instance)
 		{
-			if (!type.IsImmutableCollection)
+			if (!Type.IsImmutableCollection)
 				return instance;
 
+			MethodInfo createImmutableFromMutable;
 			// create immutable collection from List<> or Dictionary<,> using the Immutable[Type].CreateRange static method
-			if (createImmutableFromMutable == null)
-			{
-				var ti = type.UnderlyingType.GetTypeInfo();
-				var typeArgs = ti.GetGenericArguments();
-				var assembly = ti.Assembly;
-				var name = ti.GetGenericTypeDefinition().FullName;
-				var builderType = assembly.GetType(name.Substring(0, name.Length - 2)); // remove `1 or `2
-				var mi = builderType.GetRuntimeMethods().FirstOrDefault(r => r.Name == "CreateRange" && r.GetParameters().Length == 1);
-				createImmutableFromMutable = mi.MakeGenericMethod(typeArgs);
-			}
+			if (TryGetCache(s_CreateImmutableFromMutableKey, out createImmutableFromMutable))
+				return createImmutableFromMutable.Invoke(null, new[] { instance });
+
+			var ti = Type.UnderlyingType.GetTypeInfo();
+			var typeArgs = ti.GetGenericArguments();
+			var assembly = ti.Assembly;
+			var name = ti.GetGenericTypeDefinition().FullName;
+			var builderType = assembly.GetType(name.Substring(0, name.Length - 2)); // remove `1 or `2
+			var mi = builderType.GetRuntimeMethods().FirstOrDefault(r => r.Name == "CreateRange" && r.GetParameters().Length == 1);
+			createImmutableFromMutable = mi.MakeGenericMethod(typeArgs);
+			cache[s_CreateImmutableFromMutableKey] = createImmutableFromMutable;
 			return createImmutableFromMutable.Invoke(null, new[] { instance });
 		}
 
 		public virtual MethodInfo GetAddMethod(XamlType contentType)
 		{
-			return type == null || type.UnderlyingType == null || type.ItemType == null || type.CollectionKind == XamlCollectionKind.None 
+			return Type == null || Type.UnderlyingType == null || Type.ItemType == null || Type.CollectionKind == XamlCollectionKind.None 
 				? null 
-				: type.UnderlyingType.GetRuntimeMethod("Add", new Type[] { contentType.UnderlyingType });
+				: Type.UnderlyingType.GetRuntimeMethod("Add", new Type[] { contentType.UnderlyingType });
 		}
 
 		public virtual MethodInfo GetEnumeratorMethod()
 		{
-			return type == null || type.UnderlyingType == null || type.CollectionKind == XamlCollectionKind.None 
+			return Type == null || Type.UnderlyingType == null || Type.CollectionKind == XamlCollectionKind.None 
 				? null 
-				: type.UnderlyingType.GetRuntimeMethod("GetEnumerator", new Type[0]);
+				: Type.UnderlyingType.GetRuntimeMethod("GetEnumerator", new Type[0]);
 		}
 
 		public virtual IEnumerator GetItems (object instance)

--- a/src/Portable.Xaml/Portable.Xaml/PrefixLookup.cs
+++ b/src/Portable.Xaml/Portable.Xaml/PrefixLookup.cs
@@ -48,11 +48,16 @@ namespace Portable.Xaml
 
 		public string LookupPrefix (string ns)
 		{
-#if PCL136
-			var nd = Namespaces.FirstOrDefault (n => n.Namespace == ns);
-#else
-			var nd = Namespaces.Find (n => n.Namespace == ns);
-#endif
+			NamespaceDeclaration nd = null;
+			foreach (var nsd in Namespaces)
+			{
+				if (nsd.Namespace == ns)
+				{
+					nd = nsd;
+					break;
+				}
+			}
+
 			if (nd == null && IsCollectingNamespaces)
 				return AddNamespace (ns);
 			else
@@ -74,13 +79,14 @@ namespace Portable.Xaml
 			l.Add (new NamespaceDeclaration (ns, prefix));
 			return prefix;
 		}
-		
+
+		const string pre = "clr-namespace:";
+
 		string GetAcronym (string ns)
 		{
 			int idx = ns.IndexOf (';');
 			if (idx < 0)
 				return null;
-			string pre = "clr-namespace:";
 			if (!ns.StartsWith (pre, StringComparison.Ordinal))
 				return null;
 			ns = ns.Substring (pre.Length, idx - pre.Length);

--- a/src/Portable.Xaml/Portable.Xaml/TypeExtensionMethods.cs
+++ b/src/Portable.Xaml/Portable.Xaml/TypeExtensionMethods.cs
@@ -302,8 +302,7 @@ namespace Portable.Xaml
 					continue;
 				bool mismatch = false;
 				foreach (var pi in pis)
-					for (int i = 0; i < args.Count; i++)
-						mismatch |= args.All(a => a.ConstructorArgumentName() != pi.Name);
+					mismatch |= args.All(a => a.ConstructorArgumentName() != pi.Name);
 				if (mismatch)
 					continue;
 				return args.OrderBy(c => pis.FindParameterWithName(c.ConstructorArgumentName()).Position);
@@ -314,7 +313,12 @@ namespace Portable.Xaml
 
 		static ParameterInfo FindParameterWithName (this IEnumerable<ParameterInfo> pis, string name)
 		{
-			return pis.FirstOrDefault (pi => pi.Name == name);
+			foreach (var pi in pis)
+			{
+				if (pi.Name == name)
+					return pi;
+			}
+			return null;
 		}
 
 		static IEnumerable<XamlMember> FindConstructorArguments(XamlSchemaContext context, IEnumerable<ConstructorInfo> constructors, IList<object> contents, Func<XamlType, XamlType, bool> compare)

--- a/src/Portable.Xaml/Portable.Xaml/XamlMember.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlMember.cs
@@ -64,6 +64,8 @@ namespace Portable.Xaml
 		ReferenceValue<ICustomAttributeProvider> customAttributeProvider;
 		ReferenceValue<XamlValueConverter<XamlDeferringLoader>> deferringLoader;
 
+		internal XamlSchemaContext SchemaContext => context; // should we expose this as public?
+
 		public XamlMember(EventInfo eventInfo, XamlSchemaContext schemaContext)
 			: this(eventInfo, schemaContext, null)
 		{

--- a/src/Portable.Xaml/Portable.Xaml/XamlNameResolver.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlNameResolver.cs
@@ -107,8 +107,10 @@ namespace Portable.Xaml
 		public string GetName (object value)
 		{
 			foreach (var no in objects)
-				if (ReferenceEquals (no.Value.Value, value))
+			{
+				if (ReferenceEquals(no.Value.Value, value))
 					return no.Value.Name;
+			}
 			return null;
 		}
 
@@ -128,12 +130,16 @@ namespace Portable.Xaml
 			if (unnamed.Count == 0)
 				return null;
 
-#if PCL136
-			var un = unnamed.FirstOrDefault(r => ReferenceEquals(r.Value, value));
-#else
-			// faster than FirstOrDefault
-			var un = unnamed.Find(r => ReferenceEquals (r.Value, value));
-#endif
+			NamedObject un = null;
+			for (int i = 0; i < unnamed.Count; i++)
+			{
+				var r = unnamed[i];
+				if (ReferenceEquals(r.Value, value))
+				{
+					un = r;
+					break;
+				}
+			}
 			if (un == null)
 				return null;
 			

--- a/src/Portable.Xaml/Portable.Xaml/XamlNode.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlNode.cs
@@ -34,6 +34,30 @@ namespace Portable.Xaml
 {
 	class XamlNodeInfo
 	{
+		public XamlNodeInfo()
+		{
+		}
+
+		public XamlNodeInfo Set(XamlNodeType nodeType, object value)
+		{
+			NodeType = nodeType;
+			Value = value;
+			return this;
+		}
+		public XamlNodeInfo Set(object value)
+		{
+			NodeType = XamlNodeType.Value;
+			Value = value;
+			return this;
+		}
+
+		public XamlNodeInfo Set(XamlNodeInfo node)
+		{
+			NodeType = node.NodeType;
+			Value = node.Value;
+			return this;
+		}
+
 		public XamlNodeInfo(XamlNodeType nodeType, XamlObject value)
 		{
 			NodeType = nodeType;
@@ -58,13 +82,15 @@ namespace Portable.Xaml
 			Value = ns;
 		}
 
-		public XamlNodeType NodeType { get; }
+		public XamlNodeType NodeType { get; private set; }
 
 		public XamlObject Object => (XamlObject)Value;
 
 		public XamlNodeMember Member => (XamlNodeMember)Value;
 
-		public object Value { get; }
+		public object Value { get; private set; }
+
+		public XamlNodeInfo Copy() => new XamlNodeInfo().Set(this);
 	}
 
 	struct XamlNodeLineInfo
@@ -81,15 +107,26 @@ namespace Portable.Xaml
 	
 	class XamlObject
 	{
+		public XamlObject()
+		{
+		}
+
+		public XamlObject Set(XamlType type, object instance)
+		{
+			Type = type;
+			Value = instance;
+			return this;
+		}
+
 		public XamlObject (XamlType type, object instance)
 		{
 			Type = type;
 			Value = instance;
 		}
 		
-		public object Value { get; }
+		public object Value { get; private set; }
 		
-		public XamlType Type { get; }
+		public XamlType Type { get; private set; }
 
 		public object RawValue => Value;
 
@@ -117,15 +154,32 @@ namespace Portable.Xaml
 
 	class XamlNodeMember
 	{
+		public XamlNodeMember()
+		{
+		}
+
+		public XamlNodeMember Set(XamlObject owner, XamlMember member)
+		{
+			Owner = owner;
+			Member = member;
+			return this;
+		}
+
 		public XamlNodeMember (XamlObject owner, XamlMember member)
 		{
 			Owner = owner;
 			Member = member;
 		}
-		
-		public XamlObject Owner { get; }
 
-		public XamlMember Member { get; }
+		public XamlObject Owner;
+
+		public XamlMember Member;
+
+		public XamlObject GetValue(XamlObject xobj)
+		{
+			var mv = Owner.GetMemberValue(Member);
+			return xobj.Set(GetType(mv), mv);
+		}
 
 		public XamlObject Value
 		{

--- a/src/Portable.Xaml/Portable.Xaml/XamlSchemaContextSettings.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlSchemaContextSettings.cs
@@ -29,6 +29,33 @@ using Portable.Xaml.Schema;
 
 namespace Portable.Xaml
 {
+	/// <summary>
+	/// Options for member and type invokers.
+	/// </summary>
+	[EnhancedXaml, Flags]
+	public enum XamlInvokerOptions
+	{
+		/// <summary>
+		/// Use reflection, which is much slower than compiled code on each call.
+		/// </summary>
+		None = 0,
+
+		/// <summary>
+		/// Compile an expression tree to get/set/add values, which has higher startup cost but is an 
+		/// order of magnatude faster than reflection.
+		/// </summary>
+		Compile = 1,
+
+		/// <summary>
+		/// Use reflection while the expression tree is compiled in a background thread.
+		/// </summary>
+		/// <remarks>
+		/// This (might) be the best of both worlds, where it uses reflection initially, but will compile the expression tree
+		/// in a background thread and use it when it is ready.
+		/// </remarks>
+		DeferCompile = 3
+	}
+
 	public class XamlSchemaContextSettings
 	{
 		public XamlSchemaContextSettings ()
@@ -43,10 +70,15 @@ namespace Portable.Xaml
 				return;
 			FullyQualifyAssemblyNamesInClrNamespaces = s.FullyQualifyAssemblyNamesInClrNamespaces;
 			SupportMarkupExtensionsWithDuplicateArity = s.SupportMarkupExtensionsWithDuplicateArity;
+			InvokerOptions = s.InvokerOptions;
 		}
 
 		public bool FullyQualifyAssemblyNamesInClrNamespaces { get; set; }
+
 		public bool SupportMarkupExtensionsWithDuplicateArity { get; set; }
+
+		[EnhancedXaml]
+		public XamlInvokerOptions InvokerOptions { get; set; } = XamlInvokerOptions.DeferCompile;
 
 	}
 }

--- a/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
@@ -201,12 +201,12 @@ namespace Portable.Xaml
 
 			var state = object_states.Peek ();
 			var wpl = state.WrittenProperties;
-#if PCL136
-			if (wpl.Any (wp => wp.Member == property))
-#else
-			if (wpl.Find (wp => wp.Member == property) != null)
-#endif
-				throw new XamlDuplicateMemberException (String.Format ("Property '{0}' is already set to this '{1}' object", property, object_states.Peek ().Type));
+			foreach (var wp in wpl)
+			{
+				if (wp.Member == property)
+					throw new XamlDuplicateMemberException(String.Format("Property '{0}' is already set to this '{1}' object", property, object_states.Peek().Type));
+			}
+
 			wpl.Add (new MemberAndValue (property));
 			if (property == XamlLanguage.PositionalParameters)
 				state.PositionalParameterIndex = 0;


### PR DESCRIPTION
- Add NoCache benchmarks to test when we are not reusing XamlSchemaContext (e.g. using XamlServices methods)
- Optimize checking parameters for compiled expressions by using a child delegate instead of compiling it along with the expression
- Loading: Reduce allocations even more by looping instead of using Find/FirstOrDefault
- Saving: Huge reduction in allocations by sharing the XamlNodeInfo, XamlNodeMember, and XamlObject where we can
- Add XamlSchemaContext.InvokerOptions to control whether to use compiled, deferred, or reflection since each have performance implications.