### PR TITLE
Add capability to add default namespaces to XamlXmlReaderSettings.

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlXmlReaderSettings.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlXmlReaderSettings.cs
@@ -26,17 +26,21 @@ using Portable.Xaml.ComponentModel;
 using System.Reflection;
 using Portable.Xaml.Markup;
 using Portable.Xaml.Schema;
+using System.Xml;
+using System.Linq;
 
 namespace Portable.Xaml
 {
 	public class XamlXmlReaderSettings : XamlReaderSettings
 	{
-		public XamlXmlReaderSettings ()
+		Dictionary<string, string> _defaultNamespaces;
+
+		public XamlXmlReaderSettings()
 		{
 		}
 
-		public XamlXmlReaderSettings (XamlXmlReaderSettings settings)
-			: base (settings)
+		public XamlXmlReaderSettings(XamlXmlReaderSettings settings)
+			: base(settings)
 		{
 			var s = settings;
 			if (s == null)
@@ -45,11 +49,65 @@ namespace Portable.Xaml
 			SkipXmlCompatibilityProcessing = s.SkipXmlCompatibilityProcessing;
 			XmlLang = s.XmlLang;
 			XmlSpacePreserve = s.XmlSpacePreserve;
+			if (s._defaultNamespaces != null)
+				_defaultNamespaces = new Dictionary<string, string>(s._defaultNamespaces);
 		}
 
 		public bool CloseInput { get; set; }
 		public bool SkipXmlCompatibilityProcessing { get; set; }
 		public string XmlLang { get; set; }
 		public bool XmlSpacePreserve { get; set; }
+
+		/// <summary>
+		/// Adds a default namespace to read the xaml as a fragment.
+		/// </summary>
+		/// <param name="prefix">Prefix of namespace, or null for the default namespace</param>
+		/// <param name="xmlNamespace">Uri or clr-namespace to set as default</param>
+		[EnhancedXaml]
+		public void AddNamespace(string prefix, string xmlNamespace)
+		{
+			if (_defaultNamespaces == null)
+				_defaultNamespaces = new Dictionary<string, string>();
+			_defaultNamespaces[prefix ?? string.Empty] = xmlNamespace;
+		}
+
+		/// <summary>
+		/// Adds all namespace prefixes defined in the assembly of the specified type as default using <see cref="XmlnsPrefixAttribute"/>
+		/// </summary>
+		/// <param name="type">Type of the assembly to lookup default prefixes for</param>
+		[EnhancedXaml]
+		public void AddNamespaces(Type type) => AddNamespaces(type.GetTypeInfo().Assembly);
+
+		/// <summary>
+		/// Adds all namespace prefixes defined in the assembly as default using <see cref="XmlnsPrefixAttribute"/>
+		/// </summary>
+		/// <param name="assembly">Assembly to lookup default prefixes for</param>
+		[EnhancedXaml]
+		public void AddNamespaces(Assembly assembly)
+		{
+			var prefixes = assembly.GetCustomAttributes<XmlnsPrefixAttribute>();
+			foreach (var prefix in prefixes)
+			{
+				AddNamespace(prefix.Prefix, prefix.XmlNamespace);
+			}
+		}
+
+		public IEnumerable<KeyValuePair<string, string>> DefaultNamespaces => _defaultNamespaces ?? Enumerable.Empty<KeyValuePair<string, string>>();
+
+		internal bool RequiresXmlContext => _defaultNamespaces?.Count > 0;
+
+		internal XmlParserContext CreateXmlContext()
+		{
+			var nt = new NameTable();
+			var nsmgr = new XmlNamespaceManager(nt);
+
+			if (_defaultNamespaces != null)
+			{
+				foreach (var ns in _defaultNamespaces)
+					nsmgr.AddNamespace(ns.Key, ns.Value);
+			}
+
+			return new XmlParserContext(null, nsmgr, null, XmlSpace.None);
+		}
 	}
 }

--- a/src/Test/Portable.Xaml-tests-pcl259.csproj
+++ b/src/Test/Portable.Xaml-tests-pcl259.csproj
@@ -127,21 +127,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />
-    <None Include="XmlFiles\NumericValues.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="XmlFiles\NumericValues_Max.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="XmlFiles\NumericValues_PositiveInfinity.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="XmlFiles\NumericValues_NegativeInfinity.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="XmlFiles\NumericValues_NaN.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Portable.Xaml\Portable.Xaml-pcl259.csproj">

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -76,6 +76,8 @@ namespace MonoTests.Portable.Xaml.NamespaceTest
 	public class NamespaceTestClass
 	{
 		public string Foo { get; set; }
+
+		public string Bar { get; set; }
 	}
 
 	public abstract class AbstractObject

--- a/src/Test/System.Xaml/XamlXmlReaderSettingsTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderSettingsTest.cs
@@ -43,37 +43,53 @@ namespace MonoTests.Portable.Xaml
 	public class XamlXmlReaderSettingsTest
 	{
 		[Test]
-		public void DefaultValues ()
+		public void DefaultValues()
 		{
-			var s = new XamlXmlReaderSettings ();
-			Assert.IsFalse (s.CloseInput, "#1");
-			Assert.IsFalse (s.SkipXmlCompatibilityProcessing, "#2");
-			Assert.IsNull (s.XmlLang, "#3");
-			Assert.IsFalse (s.XmlSpacePreserve, "#4");
+			var s = new XamlXmlReaderSettings();
+			Assert.IsFalse(s.CloseInput, "#1");
+			Assert.IsFalse(s.SkipXmlCompatibilityProcessing, "#2");
+			Assert.IsNull(s.XmlLang, "#3");
+			Assert.IsFalse(s.XmlSpacePreserve, "#4");
 		}
 
 		[Test]
-		public void CopyConstructorNull ()
+		public void CopyConstructorNull()
 		{
-			new XamlXmlReaderSettings (null);
+			new XamlXmlReaderSettings(null);
 		}
 
 		[Test]
-		public void CopyConstructor ()
+		public void CopyConstructor()
 		{
-			var s = new XamlXmlReaderSettings ();
+			var s = new XamlXmlReaderSettings();
 			s.CloseInput = true;
 			s.SkipXmlCompatibilityProcessing = true;
 			s.XmlLang = "ja-JP";
 			s.XmlSpacePreserve = true;
 
-			s = new XamlXmlReaderSettings (s);
+			s = new XamlXmlReaderSettings(s);
 
 			// .NET fails to copy this value.
 			//Assert.IsTrue (s.CloseInput, "#1");
-			Assert.IsTrue (s.SkipXmlCompatibilityProcessing, "#2");
-			Assert.AreEqual ("ja-JP", s.XmlLang, "#3");
-			Assert.IsTrue (s.XmlSpacePreserve, "#4");
+			Assert.IsTrue(s.SkipXmlCompatibilityProcessing, "#2");
+			Assert.AreEqual("ja-JP", s.XmlLang, "#3");
+			Assert.IsTrue(s.XmlSpacePreserve, "#4");
+		}
+
+		[Test]
+		public void DefaultNamespaceFromAttributes()
+		{
+#if PCL
+			var s = new XamlXmlReaderSettings();
+			s.AddNamespaces(GetType());
+			var testNamespaces = new Dictionary<string, string>
+			{
+				{ "test", "http://schemas.example.com/test" }
+			};
+			CollectionAssert.AreEquivalent(s.DefaultNamespaces, testNamespaces);
+#else
+			Assert.Ignore("Not supported in System.Xaml");
+#endif
 		}
 	}
 }

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -50,17 +50,17 @@ namespace MonoTests.Portable.Xaml
 	{
 		// read test
 
-		XamlReader GetReader(string filename)
+		XamlReader GetReader(string filename, XamlXmlReaderSettings settings = null)
 		{
-			string xml = File.ReadAllText(Compat.GetTestFile (filename)).UpdateXml();
-			return new XamlXmlReader(XmlReader.Create(new StringReader(xml)));
+			string xml = File.ReadAllText(Compat.GetTestFile(filename)).UpdateXml();
+			return new XamlXmlReader(new StringReader(xml), new XamlSchemaContext(), settings);
 		}
-		
-		void ReadTest (string filename)
+
+		void ReadTest(string filename)
 		{
-			var r = GetReader (filename);
+			var r = GetReader(filename);
 			while (!r.IsEof)
-				r.Read ();
+				r.Read();
 		}
 
 		[Test]
@@ -964,6 +964,38 @@ namespace MonoTests.Portable.Xaml
 			Assert.AreEqual(0, obj.ByteValue, "#5");
 			Assert.AreEqual(0, obj.IntValue, "#6");
 			Assert.AreEqual(0, obj.LongValue, "#7");
+		}
+
+		[Test]
+		public void Read_DefaultNamespaces_ClrNamespace()
+		{
+#if PCL
+			var settings = new XamlXmlReaderSettings();
+			settings.AddNamespace(null, Compat.TestAssemblyNamespace);
+			settings.AddNamespace("x", XamlLanguage.Xaml2006Namespace);
+			var obj = (TestClass5)XamlServices.Load(GetReader("DefaultNamespaces.xml", settings));
+			Assert.IsNotNull(obj, "#1");
+			Assert.AreEqual(obj.Bar, "Hello");
+			Assert.AreEqual(obj.Baz, null);
+#else
+			Assert.Ignore("Not supported in System.Xaml");
+#endif
+		}
+
+		[Test]
+		public void Read_DefaultNamespaces_WithDefinedNamespace()
+		{
+#if PCL
+			var settings = new XamlXmlReaderSettings();
+			settings.AddNamespace(null, "urn:mono-test");
+			settings.AddNamespace("x", "urn:mono-test2");
+			var obj = (NamespaceTest.NamespaceTestClass)XamlServices.Load(GetReader("DefaultNamespaces_WithDefinedNamespace.xml", settings));
+			Assert.IsNotNull(obj, "#1");
+			Assert.AreEqual(obj.Foo, "Hello");
+			Assert.AreEqual(obj.Bar, null);
+#else
+			Assert.Ignore("Not supported in System.Xaml");
+#endif
 		}
 	}
 }

--- a/src/Test/XmlFiles/DefaultNamespaces.xml
+++ b/src/Test/XmlFiles/DefaultNamespaces.xml
@@ -1,0 +1,1 @@
+<TestClass5 Bar="Hello" Baz="{x:Null}" />

--- a/src/Test/XmlFiles/DefaultNamespaces_WithDefinedNamespace.xml
+++ b/src/Test/XmlFiles/DefaultNamespaces_WithDefinedNamespace.xml
@@ -1,0 +1,1 @@
+<NamespaceTestClass xmlns="urn:mono-test" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Foo="Hello" Bar="{x:Null}" />


### PR DESCRIPTION
Adds the following API:
- XamlXmlReaderSettings.AddNamespace(string, string)
- XamlXmlReaderSettings.AddNamespaces(Type)
- XamlXmlReaderSettings.AddNamespaces(Assembly)
- XamlXmlReaderSettings.DefaultNamespaces

Fixes #42.