### PR TITLE
Collection order and immutable object fixes

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml.Schema/XamlMemberInvoker.cs
+++ b/src/Portable.Xaml/Portable.Xaml.Schema/XamlMemberInvoker.cs
@@ -151,5 +151,28 @@ namespace Portable.Xaml.Schema
 		{
 			throw new NotImplementedException();
 		}
+
+		/// <summary>
+		/// Gets a value indicating that the instance is considered the default value of the member.
+		/// </summary>
+		/// <remarks>
+		/// This uses the DefaultValueAttribute normally, but for immutable structs this is also useful to  define that 
+		/// the value is default.
+		/// 
+		/// E.g. for immutable collections, this uses the IsDefault property to determine if it should be written to xaml.
+		/// </remarks>
+		/// <returns><c>true</c>, if the instance is the default value, <c>false</c> otherwise.</returns>
+		/// <param name="instance">instance of the object to test if it is default.</param>
+		[EnhancedXaml]
+		public virtual bool IsDefaultValue(object instance)
+		{
+			if (Member == null)
+				return false;
+			if (Member.DefaultValue != null)
+				return Equals(Member.DefaultValue.Value, instance);
+			if (Member.Type?.IsMutableDefault(instance) == true)
+				return true;
+			return false;
+		}
 	}
 }

--- a/src/Portable.Xaml/Portable.Xaml.Schema/XamlTypeInvoker.cs
+++ b/src/Portable.Xaml/Portable.Xaml.Schema/XamlTypeInvoker.cs
@@ -317,6 +317,11 @@ namespace Portable.Xaml.Schema
 		{
 			if (instance == null)
 				throw new ArgumentNullException (nameof(instance));
+
+			// cannot get enumerator of immutable collections
+			if (Type?.IsMutableDefault(instance) == true)
+				return Enumerable.Empty<object>().GetEnumerator();
+
 			return ((IEnumerable) instance).GetEnumerator ();
 		}
 	}

--- a/src/Portable.Xaml/Portable.Xaml/XamlNameResolver.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlNameResolver.cs
@@ -209,10 +209,17 @@ namespace Portable.Xaml
 			CanAssignDirectly = canAssignDirectly;
 			Names = names.ToArray ();
 		}
-		
-		public XamlType ParentType { get; set; }
-		public XamlMember ParentMember { get; set; }
-		public object ParentValue { get; set; }
+
+		public XamlWriterInternalBase.ObjectState ParentState { get; set; }
+		public XamlWriterInternalBase.MemberAndValue ParentMemberState { get; set; }
+		public XamlWriterInternalBase.ObjectState State { get; set; }
+		public XamlWriterInternalBase.MemberAndValue MemberState { get; set; }
+		public XamlType Type => State.Type;
+		public XamlMember Member => MemberState.Member;
+		public object Value => State.Value;
+		public object KeyValue => State.KeyValue;
+
+		public int? ListIndex { get; set; }
 
 		public bool CanAssignDirectly { get; set; }
 		public IList<string> Names { get; set; }

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectNodeIterator.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectNodeIterator.cs
@@ -132,7 +132,7 @@ namespace Portable.Xaml
 				}
 
 				// don't serialize default values if one is explicitly specified using the DefaultValueAttribute
-				if (!partOfPositionalParameters && xm.DefaultValue != null && Equals(xm.DefaultValue.Value, val))
+				if (!partOfPositionalParameters && xm.Invoker.IsDefaultValue(val))
 					yield break;
 
 				// overrideMemberType is (so far) used for XamlLanguage.Key.

--- a/src/Portable.Xaml/Portable.Xaml/XamlType.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlType.cs
@@ -948,5 +948,20 @@ namespace Portable.Xaml
 				.ToList ();
 			return constructorArguments;
 		}
+
+		internal bool IsMutableDefault(object instance)
+		{
+			if (!IsImmutableCollection)
+				return false;
+			var isDefaultProperty = UnderlyingType?.GetRuntimeProperty("IsDefault");
+			if (isDefaultProperty != null)
+			{
+				var isDefault = isDefaultProperty.GetValue(instance, null) as bool?;
+				if (isDefault == true)
+					return true;
+			}
+			return false;
+		}
+
 	}
 }

--- a/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
@@ -78,6 +78,11 @@ namespace Portable.Xaml
 			public List<MemberAndValue> WrittenProperties = new List<MemberAndValue> ();
 			public bool IsInstantiated;
 			public bool IsXamlWriterCreated; // affects AfterProperties() calls.
+
+			public MemberAndValue CurrentMemberState
+			{
+				get { return WrittenProperties.Count > 0 ? WrittenProperties[WrittenProperties.Count - 1] : null; }
+			}
 		}
 
 		object IProvideValueTarget.TargetObject => object_states.Peek().Value;
@@ -131,20 +136,13 @@ namespace Portable.Xaml
 			{
 				if (object_states.Count > 0)
 				{
-					var properties = object_states.Peek().WrittenProperties;
-					if (properties.Count > 0)
-						return properties[properties.Count - 1];
+					return object_states.Peek().CurrentMemberState;
 				}
 				return null;
 			}
 		}
 
-		protected XamlMember CurrentMember {
-			get {
-				var mv = CurrentMemberState;
-				return mv != null ? mv.Member : null;
-			}
-		}
+		protected XamlMember CurrentMember => CurrentMemberState?.Member;
 
 		public void WriteGetObject ()
 		{

--- a/src/Portable.Xaml/Portable.Xaml/XamlXmlWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlXmlWriter.cs
@@ -374,7 +374,7 @@ namespace Portable.Xaml
 			if (object_states.Count == 1)
 				return true;
 			var tmp = object_states.Pop ();
-			var parentMember = object_states.Peek ().WrittenProperties.LastOrDefault ().Member;
+			var parentMember = object_states.Peek().CurrentMemberState?.Member;
 			object_states.Push (tmp);
 
 			return parentMember == XamlLanguage.Items;

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -53,22 +53,22 @@ using System.Xaml.Schema;
 #endif
 
 [assembly: XmlnsDefinition("http://www.domain.com/path", "XamlTest")]
- // bug #680385
+// bug #680385
 [assembly: XmlnsDefinition("http://www.domain.com/path", "SecondTest")]
- // bug #681045, same xmlns key for different clrns.
+// bug #681045, same xmlns key for different clrns.
 
 [assembly: XmlnsDefinition("http://schemas.example.com/test", "XamarinBug3003")]
- // bug #3003
+// bug #3003
 [assembly: XmlnsPrefix("http://schemas.example.com/test", "test")]
- // bug #3003
+// bug #3003
 
-[assembly:XmlnsDefinition("urn:mono-test", "MonoTests.Portable.Xaml.NamespaceTest")]
-[assembly:XmlnsDefinition("urn:mono-test2", "MonoTests.Portable.Xaml.NamespaceTest2")]
+[assembly: XmlnsDefinition("urn:mono-test", "MonoTests.Portable.Xaml.NamespaceTest")]
+[assembly: XmlnsDefinition("urn:mono-test2", "MonoTests.Portable.Xaml.NamespaceTest2")]
 
 // comment out the following to get mono's System.Xaml to go further in the tests
 [assembly: XmlnsDefinition("urn:bar", "MonoTests.Portable.Xaml.NamespaceTest")]
 
-[assembly:XmlnsCompatibleWith("urn:foo", "urn:bar")]
+[assembly: XmlnsCompatibleWith("urn:foo", "urn:bar")]
 [assembly: XmlnsCompatibleWith("urn:foo2", "urn:bar2")]
 
 namespace MonoTests.Portable.Xaml.NamespaceTest
@@ -90,10 +90,10 @@ namespace MonoTests.Portable.Xaml.NamespaceTest
 		public override string Foo { get; set; }
 	}
 
-	[ContentProperty ("Contents")]
+	[ContentProperty("Contents")]
 	public class CustomGenericType<T>
 	{
-		public List<T> Contents { get; } = new List<T> ();
+		public List<T> Contents { get; } = new List<T>();
 	}
 }
 
@@ -117,9 +117,9 @@ namespace MonoTests.Portable.Xaml
 
 	[ContentProperty("Contents")]
 	public class CustomGenericType<T>
-		where T: struct
+		where T : struct
 	{
-		public List<T> Contents { get; } = new List<T> ();
+		public List<T> Contents { get; } = new List<T>();
 	}
 
 	public class ArgumentNonAttributed
@@ -141,12 +141,12 @@ namespace MonoTests.Portable.Xaml
 
 		public string StringArg { get; private set; }
 
-		public ArgumentMultipleTypes (int arg1)
+		public ArgumentMultipleTypes(int arg1)
 		{
 			IntArg = arg1;
 		}
 
-		public ArgumentMultipleTypes (string arg1)
+		public ArgumentMultipleTypes(string arg1)
 		{
 			StringArg = arg1;
 		}
@@ -157,7 +157,7 @@ namespace MonoTests.Portable.Xaml
 	{
 		public int IntArg { get; private set; }
 
-		public ArgumentWithIntConstructor (int arg1)
+		public ArgumentWithIntConstructor(int arg1)
 		{
 			IntArg = arg1;
 		}
@@ -213,7 +213,7 @@ namespace MonoTests.Portable.Xaml
 	{
 		public string Foo { get; set; }
 	}
-	
+
 	//[MarkupExtensionReturnType (typeof (Array))]
 	//[ContentProperty ("Items")]  ... so, these attributes do not affect XamlObjectReader.
 	public class MyArrayExtension : MarkupExtension
@@ -679,13 +679,13 @@ namespace MonoTests.Portable.Xaml
 	{
 		public XData Markup { get; set; }
 	}
-	
+
 	// FIXME: test it with XamlXmlReader (needs to create xml first)
 	public class EventContainer
 	{
-		#pragma warning disable 67
+#pragma warning disable 67
 		public event Action Run;
-		#pragma warning restore 67
+#pragma warning restore 67
 	}
 
 	public class NamedItem
@@ -723,6 +723,15 @@ namespace MonoTests.Portable.Xaml
 		public string ItemName { get; set; }
 
 		public IList<NamedItem2> References { get; private set; }
+	}
+
+	public class NamedItem3 : NamedItem2
+	{
+		public NamedItem2 Other { get; set; }
+
+#if !PCL136
+		public ImmutableArray<NamedItem3> ImmutableReferences { get; set; }
+#endif
 	}
 
 	[TypeConverter(typeof(TestValueConverter))]

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -94,7 +94,7 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void SchemaContextNull()
 		{
-			Assert.Throws<ArgumentNullException> (() => new XamlObjectWriter(null));
+			Assert.Throws<ArgumentNullException>(() => new XamlObjectWriter(null));
 		}
 
 		[Test]
@@ -108,31 +108,31 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void InitWriteEndMember()
 		{
-			Assert.Throws<XamlObjectWriterException> (() => new XamlObjectWriter(sctx, null).WriteEndMember());
+			Assert.Throws<XamlObjectWriterException>(() => new XamlObjectWriter(sctx, null).WriteEndMember());
 		}
 
 		[Test]
 		public void InitWriteEndObject()
 		{
-			Assert.Throws<XamlObjectWriterException> (() => new XamlObjectWriter(sctx, null).WriteEndObject());
+			Assert.Throws<XamlObjectWriterException>(() => new XamlObjectWriter(sctx, null).WriteEndObject());
 		}
 
 		[Test]
 		public void InitWriteGetObject()
 		{
-			Assert.Throws<XamlObjectWriterException> (() => new XamlObjectWriter(sctx, null).WriteGetObject());
+			Assert.Throws<XamlObjectWriterException>(() => new XamlObjectWriter(sctx, null).WriteGetObject());
 		}
 
 		[Test]
 		public void InitWriteValue()
 		{
-			Assert.Throws<XamlObjectWriterException> (() => new XamlObjectWriter(sctx, null).WriteValue("foo"));
+			Assert.Throws<XamlObjectWriterException>(() => new XamlObjectWriter(sctx, null).WriteValue("foo"));
 		}
 
 		[Test]
 		public void InitWriteStartMember()
 		{
-			Assert.Throws<XamlObjectWriterException> (() => new XamlObjectWriter(sctx, null).WriteStartMember(new XamlMember(str_len, sctx)));
+			Assert.Throws<XamlObjectWriterException>(() => new XamlObjectWriter(sctx, null).WriteStartMember(new XamlMember(str_len, sctx)));
 		}
 
 		[Test]
@@ -147,7 +147,7 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void WriteNamespaceNull()
 		{
-			Assert.Throws<ArgumentNullException> (() => new XamlObjectWriter(sctx, null).WriteNamespace(null));
+			Assert.Throws<ArgumentNullException>(() => new XamlObjectWriter(sctx, null).WriteNamespace(null));
 		}
 
 		[Test]
@@ -164,7 +164,7 @@ namespace MonoTests.Portable.Xaml
 		{
 			var xw = new XamlObjectWriter(sctx, null);
 			xw.WriteStartObject(xt3);
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteGetObject());
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteGetObject());
 		}
 
 		[Test]
@@ -184,7 +184,7 @@ namespace MonoTests.Portable.Xaml
 			var xw = new XamlObjectWriter(sctx, null);
 			xw.WriteStartObject(xt3);
 			xw.WriteEndObject();
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteEndObject());
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteEndObject());
 		}
 
 		[Test]
@@ -192,7 +192,7 @@ namespace MonoTests.Portable.Xaml
 		{
 			var xw = new XamlObjectWriter(sctx, null);
 			xw.WriteStartObject(xt3);
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteEndMember());
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteEndMember());
 		}
 
 		[Test]
@@ -222,7 +222,7 @@ namespace MonoTests.Portable.Xaml
 			var xw = new XamlObjectWriter(sctx, null);
 			xw.WriteStartObject(xt3);
 			xw.WriteStartMember(xm3);
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteStartMember(xm3));
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteStartMember(xm3));
 		}
 
 		[Test]
@@ -249,7 +249,7 @@ namespace MonoTests.Portable.Xaml
 			Assert.Throws<XamlDuplicateMemberException>(() =>
 			{
 				xw.WriteValue("foo"); // Portable.Xaml throws here
-				// rejected here, unlike XamlXmlWriter.
+									  // rejected here, unlike XamlXmlWriter.
 				xw.WriteEndMember(); // .NET 4.5 throws here
 			});
 		}
@@ -295,7 +295,7 @@ namespace MonoTests.Portable.Xaml
 			xw.WriteStartObject(xt3);
 			xw.WriteEndObject();
 			xw.WriteEndMember();
-			Assert.Throws<XamlDuplicateMemberException> (() => xw.WriteStartMember(xm3));
+			Assert.Throws<XamlDuplicateMemberException>(() => xw.WriteStartMember(xm3));
 		}
 
 		[Test]
@@ -371,7 +371,7 @@ namespace MonoTests.Portable.Xaml
 			xw.WriteStartObject(xt);
 			xw.WriteStartMember(XamlLanguage.Initialization);
 			xw.WriteValue("foo");
-			Assert.Throws<XamlObjectWriterException> (() => xw.Close());
+			Assert.Throws<XamlObjectWriterException>(() => xw.Close());
 		}
 
 		[Test]
@@ -379,7 +379,7 @@ namespace MonoTests.Portable.Xaml
 		{
 			var xw = new XamlObjectWriter(sctx, null);
 			xw.WriteStartObject(xt);
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteValue("foo"));
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteValue("foo"));
 			//xw.WriteValue("bar");
 		}
 
@@ -388,7 +388,7 @@ namespace MonoTests.Portable.Xaml
 		{
 			var xw = new XamlObjectWriter(sctx, null);
 			xw.WriteStartObject(xt);
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteValue(null));
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteValue(null));
 			//xw.WriteValue("bar");
 		}
 
@@ -397,7 +397,7 @@ namespace MonoTests.Portable.Xaml
 			var xw = new XamlObjectWriter(sctx, null);
 			xw.WriteStartObject(xt3);
 			xw.WriteStartMember(xm3);
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteEndObject());
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteEndObject());
 		}
 
 		[Test]
@@ -418,7 +418,7 @@ namespace MonoTests.Portable.Xaml
 		{
 			var xw = new XamlObjectWriter(sctx, null);
 			xw.WriteStartObject(xt3);
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteStartObject(xt3));
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteStartObject(xt3));
 		}
 
 		[Test]
@@ -426,7 +426,7 @@ namespace MonoTests.Portable.Xaml
 		{
 			var xw = new XamlObjectWriter(sctx, null);
 			xw.WriteStartObject(xt3);
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteValue("foo"));
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteValue("foo"));
 		}
 
 		[Test]
@@ -496,7 +496,7 @@ namespace MonoTests.Portable.Xaml
 			xw.WriteStartObject(xt);
 			xw.WriteStartMember(XamlLanguage.Initialization);
 			xw.WriteNamespace(new NamespaceDeclaration("urn:foo", "y"));
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteValue("foo"));
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteValue("foo"));
 		}
 
 		[Test]
@@ -521,7 +521,7 @@ namespace MonoTests.Portable.Xaml
 			xw.WriteStartObject(xt3);
 			xw.WriteStartMember(xm2);
 			xw.WriteValue("foo");
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteNamespace(new NamespaceDeclaration("y", "urn:foo"))); // this does not raise an error (since it might start another object)
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteNamespace(new NamespaceDeclaration("y", "urn:foo"))); // this does not raise an error (since it might start another object)
 		}
 
 		[Test]
@@ -532,7 +532,7 @@ namespace MonoTests.Portable.Xaml
 			xw.WriteStartObject(xt3);
 			xw.WriteStartMember(xm2);
 			xw.WriteValue("foo");
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteNamespace(new NamespaceDeclaration("y", "urn:foo")));
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteNamespace(new NamespaceDeclaration("y", "urn:foo")));
 			xw.WriteEndMember();
 		}
 
@@ -542,7 +542,7 @@ namespace MonoTests.Portable.Xaml
 		{
 			var xw = new XamlObjectWriter(sctx, null);
 			xw.WriteStartObject(xt3);
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteNamespace(new NamespaceDeclaration("urn:foo", "y")));
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteNamespace(new NamespaceDeclaration("urn:foo", "y")));
 		}
 
 		[Test]
@@ -566,7 +566,7 @@ namespace MonoTests.Portable.Xaml
 			// and here, NamespaceDeclaration is written as if it 
 			// were another value object( unlike XamlXmlWriter)
 			// and rejects further value.
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteValue("foo"));
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteValue("foo"));
 		}
 
 		[Test]
@@ -577,7 +577,7 @@ namespace MonoTests.Portable.Xaml
 			xw.WriteStartMember(xm2);
 			xw.WriteValue("foo");
 			xw.WriteEndMember();
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteStartObject(xt3));
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteStartObject(xt3));
 		}
 
 		// The semantics on WriteGetObject() is VERY different from XamlXmlWriter.
@@ -588,7 +588,7 @@ namespace MonoTests.Portable.Xaml
 			var xw = new XamlObjectWriter(sctx, null);
 			xw.WriteStartObject(xt3);
 			xw.WriteStartMember(xm2);
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteGetObject());
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteGetObject());
 		}
 
 		[Test]
@@ -597,7 +597,7 @@ namespace MonoTests.Portable.Xaml
 			var xw = new XamlObjectWriter(sctx, null);
 			xw.WriteStartObject(xt4);
 			xw.WriteStartMember(new XamlMember(typeof(Foo).GetProperty("Baz"), sctx)); // unlike Bar, Baz is not initialized.
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteGetObject()); // fails, because it is null.
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteGetObject()); // fails, because it is null.
 		}
 
 		[Test]
@@ -639,7 +639,7 @@ namespace MonoTests.Portable.Xaml
 			xw.WriteStartObject(xt4);
 			xw.WriteStartMember(new XamlMember(typeof(Foo).GetProperty("Bar"), sctx));
 			xw.WriteGetObject();
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteValue("foo"));
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteValue("foo"));
 		}
 
 		[Test]
@@ -649,7 +649,7 @@ namespace MonoTests.Portable.Xaml
 			xw.WriteStartObject(xt4);
 			xw.WriteStartMember(new XamlMember(typeof(Foo).GetProperty("Bar"), sctx));
 			xw.WriteGetObject();
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteStartObject(xt));
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteStartObject(xt));
 		}
 
 		[Test]
@@ -659,7 +659,7 @@ namespace MonoTests.Portable.Xaml
 			xw.WriteStartObject(xt4);
 			xw.WriteStartMember(new XamlMember(typeof(Foo).GetProperty("Bar"), sctx));
 			xw.WriteGetObject();
-			Assert.Throws<XamlObjectWriterException> (() => xw.WriteEndMember()); // ...!?
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteEndMember()); // ...!?
 		}
 
 		[Test]
@@ -697,9 +697,11 @@ namespace MonoTests.Portable.Xaml
 			Attached2 result = null;
 
 			var rsettings = new XamlXmlReaderSettings();
-			using (var reader = new XamlXmlReader (new StringReader (String.Format (@"<Attached2 AttachedWrapper3.Property=""Test"" xmlns=""clr-namespace:MonoTests.Portable.Xaml;assembly={0}""></Attached2>", typeof(AttachedWrapper3).Assembly.GetName ().Name)), rsettings)) {
+			using (var reader = new XamlXmlReader(new StringReader(String.Format(@"<Attached2 AttachedWrapper3.Property=""Test"" xmlns=""clr-namespace:MonoTests.Portable.Xaml;assembly={0}""></Attached2>", typeof(AttachedWrapper3).Assembly.GetName().Name)), rsettings))
+			{
 				var wsettings = new XamlObjectWriterSettings();
-				using (var writer = new XamlObjectWriter (reader.SchemaContext, wsettings)) {
+				using (var writer = new XamlObjectWriter(reader.SchemaContext, wsettings))
+				{
 					XamlServices.Transform(reader, writer, false);
 					result = (Attached2)writer.Result;
 				}
@@ -722,7 +724,8 @@ namespace MonoTests.Portable.Xaml
 			var xml = "<TestClass3 xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'><TestClass3.Nested><TestClass3 Nested='{x:Null}' /></TestClass3.Nested></TestClass3>".Replace("net_4_0", Compat.Version);
 			var settings = new XamlObjectWriterSettings();
 			bool invoked = false;
-			settings.XamlSetValueHandler = (sender, e) => {
+			settings.XamlSetValueHandler = (sender, e) =>
+			{
 				invoked = true;
 				Assert.IsNotNull(sender, "#1");
 				Assert.AreEqual(typeof(TestClass3), sender.GetType(), "#2");
@@ -751,20 +754,25 @@ namespace MonoTests.Portable.Xaml
 			var reader = new XamlXmlReader(XmlReader.Create(new StringReader(XamarinBug3003.TestContext.XmlInput)), context);
 
 			var writerSettings = new XamlObjectWriterSettings();
-			writerSettings.AfterBeginInitHandler = (sender, e) => {
+			writerSettings.AfterBeginInitHandler = (sender, e) =>
+			{
 				output.WriteLine("XamlObjectWriterSettings.AfterBeginInit: {0}", e.Instance);
 			};
-			writerSettings.AfterEndInitHandler = (sender, e) => {
+			writerSettings.AfterEndInitHandler = (sender, e) =>
+			{
 				output.WriteLine("XamlObjectWriterSettings.AfterEndInit: {0}", e.Instance);
 			};
 
-			writerSettings.BeforePropertiesHandler = (sender, e) => {
+			writerSettings.BeforePropertiesHandler = (sender, e) =>
+			{
 				output.WriteLine("XamlObjectWriterSettings.BeforeProperties: {0}", e.Instance);
 			};
-			writerSettings.AfterPropertiesHandler = (sender, e) => {
+			writerSettings.AfterPropertiesHandler = (sender, e) =>
+			{
 				output.WriteLine("XamlObjectWriterSettings.AfterProperties: {0}", e.Instance);
 			};
-			writerSettings.XamlSetValueHandler = (sender, e) => {
+			writerSettings.XamlSetValueHandler = (sender, e) =>
+			{
 				output.WriteLine("XamlObjectWriterSettings.XamlSetValue: {0}, Member: {1}", e.Value, e.Member.Name);
 			};
 
@@ -820,7 +828,7 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void LookupCorrectEventBoundMethod2()
 		{
-			Assert.Throws<XamlObjectWriterException> (() => XamlServices.Load(GetReader("LookupCorrectEvent2.xml")));
+			Assert.Throws<XamlObjectWriterException>(() => XamlServices.Load(GetReader("LookupCorrectEvent2.xml")));
 		}
 
 		[Test]
@@ -833,14 +841,15 @@ namespace MonoTests.Portable.Xaml
 
 		XamlReader GetReader(string filename)
 		{
-			string xml = File.ReadAllText(Compat.GetTestFile (filename)).UpdateXml();
+			string xml = File.ReadAllText(Compat.GetTestFile(filename)).UpdateXml();
 			return new XamlXmlReader(XmlReader.Create(new StringReader(xml)));
 		}
 
 		[Test]
 		public void Write_String()
 		{
-			using (var xr = GetReader ("String.xml")) {
+			using (var xr = GetReader("String.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual("foo", des, "#1");
 			}
@@ -849,7 +858,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_Int32()
 		{
-			using (var xr = GetReader ("Int32.xml")) {
+			using (var xr = GetReader("Int32.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual(5, des, "#1");
 			}
@@ -858,7 +868,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_DateTime()
 		{
-			using (var xr = GetReader ("DateTime.xml")) {
+			using (var xr = GetReader("DateTime.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual(new DateTime(2010, 4, 14), des, "#1");
 			}
@@ -867,7 +878,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_TimeSpan()
 		{
-			using (var xr = GetReader ("TimeSpan.xml")) {
+			using (var xr = GetReader("TimeSpan.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual(TimeSpan.FromMinutes(7), des, "#1");
 			}
@@ -876,7 +888,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_Uri()
 		{
-			using (var xr = GetReader ("Uri.xml")) {
+			using (var xr = GetReader("Uri.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual(new Uri("urn:foo"), des, "#1");
 			}
@@ -885,7 +898,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_Null()
 		{
-			using (var xr = GetReader ("NullExtension.xml")) {
+			using (var xr = GetReader("NullExtension.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.IsNull(des, "#1");
 			}
@@ -894,7 +908,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_Type()
 		{
-			using (var xr = GetReader ("Type.xml")) {
+			using (var xr = GetReader("Type.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual(typeof(int), des, "#1");
 			}
@@ -904,7 +919,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_Type2()
 		{
 			var obj = typeof(MonoTests.Portable.Xaml.TestClass1);
-			using (var xr = GetReader ("Type2.xml")) {
+			using (var xr = GetReader("Type2.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual(obj, des, "#1");
 			}
@@ -914,7 +930,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_Guid()
 		{
 			var obj = Guid.Parse("9c3345ec-8922-4662-8e8d-a4e41f47cf09");
-			using (var xr = GetReader ("Guid.xml")) {
+			using (var xr = GetReader("Guid.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual(obj, des, "#1");
 			}
@@ -924,7 +941,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_GuidFactoryMethod()
 		{
 			var obj = Guid.Parse("9c3345ec-8922-4662-8e8d-a4e41f47cf09");
-			using (var xr = GetReader ("GuidFactoryMethod.xml")) {
+			using (var xr = GetReader("GuidFactoryMethod.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual(obj, des, "#1");
 			}
@@ -934,15 +952,17 @@ namespace MonoTests.Portable.Xaml
 		public void Write_StaticExtension()
 		{
 			var obj = new StaticExtension("FooBar");
-			using (var xr = GetReader ("StaticExtension.xml")) {
-				Assert.Throws<XamlObjectWriterException> (() => XamlServices.Load(xr));
+			using (var xr = GetReader("StaticExtension.xml"))
+			{
+				Assert.Throws<XamlObjectWriterException>(() => XamlServices.Load(xr));
 			}
 		}
 
 		[Test]
 		public void Write_Reference()
 		{
-			using (var xr = GetReader ("Reference.xml")) {
+			using (var xr = GetReader("Reference.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				// .NET does not return Reference.
 				// Its ProvideValue() returns MS.Internal.Xaml.Context.NameFixupToken,
@@ -956,7 +976,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_ArrayInt32()
 		{
 			var obj = new int[] { 4, -5, 0, 255, int.MaxValue };
-			using (var xr = GetReader ("Array_Int32.xml")) {
+			using (var xr = GetReader("Array_Int32.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual(obj, des, "#1");
 			}
@@ -966,7 +987,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_ListInt32()
 		{
 			var obj = new int[] { 5, -3, int.MaxValue, 0 }.ToList();
-			using (var xr = GetReader ("List_Int32.xml")) {
+			using (var xr = GetReader("List_Int32.xml"))
+			{
 				var des = (List<int>)XamlServices.Load(xr);
 				Assert.AreEqual(obj.ToArray(), des.ToArray(), "#1");
 			}
@@ -976,7 +998,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_ListInt32_2()
 		{
 			var obj = new List<int>(new int[0]) { Capacity = 0 }; // set explicit capacity for trivial implementation difference
-			using (var xr = GetReader ("List_Int32_2.xml")) {
+			using (var xr = GetReader("List_Int32_2.xml"))
+			{
 				var des = (List<int>)XamlServices.Load(xr);
 				Assert.AreEqual(obj.ToArray(), des.ToArray(), "#1");
 			}
@@ -986,7 +1009,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_ListType()
 		{
 			var obj = new List<Type>(new Type[] { typeof(int), typeof(Dictionary<Type, XamlType>) }) { Capacity = 2 };
-			using (var xr = GetReader ("List_Type.xml")) {
+			using (var xr = GetReader("List_Type.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual(obj, des, "#1");
 			}
@@ -996,7 +1020,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_ListArray()
 		{
 			var obj = new List<Array>(new Array[] { new int[] { 1, 2, 3 }, new string[] { "foo", "bar", "baz" } }) { Capacity = 2 };
-			using (var xr = GetReader ("List_Array.xml")) {
+			using (var xr = GetReader("List_Array.xml"))
+			{
 				var des = (List<Array>)XamlServices.Load(xr);
 				Assert.AreEqual(obj, des, "#1");
 			}
@@ -1009,7 +1034,8 @@ namespace MonoTests.Portable.Xaml
 			dic.Add(0, "foo");
 			dic.Add(5, "bar");
 			dic.Add(-2, "baz");
-			using (var xr = GetReader ("Dictionary_Int32_String.xml")) {
+			using (var xr = GetReader("Dictionary_Int32_String.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual(dic, des, "#1");
 			}
@@ -1025,7 +1051,8 @@ namespace MonoTests.Portable.Xaml
 			dic.Add("t4", typeof(List<int>));
 			dic.Add("t5", typeof(Dictionary<int, DateTime>));
 			dic.Add("t6", typeof(List<KeyValuePair<int, DateTime>>));
-			using (var xr = GetReader ("Dictionary_String_Type.xml")) {
+			using (var xr = GetReader("Dictionary_String_Type.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual(dic, des, "#1");
 			}
@@ -1036,7 +1063,8 @@ namespace MonoTests.Portable.Xaml
 		{
 			// Unlike the above case, this has the wrapper object and hence PositionalParametersClass1 can be written as an attribute (markup extension)
 			var obj = new PositionalParametersWrapper("foo", 5);
-			using (var xr = GetReader ("PositionalParametersWrapper.xml")) {
+			using (var xr = GetReader("PositionalParametersWrapper.xml"))
+			{
 				var des = XamlServices.Load(xr) as PositionalParametersWrapper;
 				Assert.IsNotNull(des, "#1");
 				Assert.IsNotNull(des.Body, "#2");
@@ -1049,7 +1077,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_ArgumentAttributed()
 		{
 			//var obj = new ArgumentAttributed ("foo", "bar");
-			using (var xr = GetReader ("ArgumentAttributed.xml")) {
+			using (var xr = GetReader("ArgumentAttributed.xml"))
+			{
 				var des = (ArgumentAttributed)XamlServices.Load(xr);
 				Assert.AreEqual("foo", des.Arg1, "#1");
 				Assert.AreEqual("bar", des.Arg2, "#2");
@@ -1060,7 +1089,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_ArgumentNonAttributed()
 		{
 			//var obj = new ArgumentNonAttributed ("foo", "bar");
-			using (var xr = GetReader ("ArgumentNonAttributed.xml")) {
+			using (var xr = GetReader("ArgumentNonAttributed.xml"))
+			{
 				var des = (ArgumentNonAttributed)XamlServices.Load(xr);
 				Assert.AreEqual("foo", des.Arg1, "#1");
 				Assert.AreEqual("bar", des.Arg2, "#2");
@@ -1068,62 +1098,68 @@ namespace MonoTests.Portable.Xaml
 		}
 
 		[Test]
-		public void Write_ArgumentMultipleTypesFromString ()
+		public void Write_ArgumentMultipleTypesFromString()
 		{
-			using (var xr = GetReader ("ArgumentMultipleTypesFromString.xml")) {
-				var des = (ArgumentMultipleTypes)XamlServices.Load (xr);
-				Assert.AreEqual ("foo", des.StringArg, "#1");
-				Assert.AreEqual (0, des.IntArg, "#2");
+			using (var xr = GetReader("ArgumentMultipleTypesFromString.xml"))
+			{
+				var des = (ArgumentMultipleTypes)XamlServices.Load(xr);
+				Assert.AreEqual("foo", des.StringArg, "#1");
+				Assert.AreEqual(0, des.IntArg, "#2");
 			}
 		}
 		[Test]
-		public void Write_ArgumentMultipleTypesFromInt ()
+		public void Write_ArgumentMultipleTypesFromInt()
 		{
-			using (var xr = GetReader ("ArgumentMultipleTypesFromInt.xml")) {
-				var des = (ArgumentMultipleTypes)XamlServices.Load (xr);
-				Assert.AreEqual (null, des.StringArg, "#1");
-				Assert.AreEqual (10, des.IntArg, "#2");
-			}
-		}
-
-		[Test]
-		public void Write_ArgumentMultipleTypesFromAttribute ()
-		{
-			using (var xr = GetReader ("ArgumentMultipleTypesFromAttribute.xml")) {
-				var des = (ArgumentMultipleTypes)XamlServices.Load (xr);
-				Assert.AreEqual ("foo", des.StringArg, "#1");
-				Assert.AreEqual (0, des.IntArg, "#2");
+			using (var xr = GetReader("ArgumentMultipleTypesFromInt.xml"))
+			{
+				var des = (ArgumentMultipleTypes)XamlServices.Load(xr);
+				Assert.AreEqual(null, des.StringArg, "#1");
+				Assert.AreEqual(10, des.IntArg, "#2");
 			}
 		}
 
 		[Test]
-		public void Write_ArgumentWithIntConstructorFromAttribute ()
+		public void Write_ArgumentMultipleTypesFromAttribute()
+		{
+			using (var xr = GetReader("ArgumentMultipleTypesFromAttribute.xml"))
+			{
+				var des = (ArgumentMultipleTypes)XamlServices.Load(xr);
+				Assert.AreEqual("foo", des.StringArg, "#1");
+				Assert.AreEqual(0, des.IntArg, "#2");
+			}
+		}
+
+		[Test]
+		public void Write_ArgumentWithIntConstructorFromAttribute()
 		{
 			if (!Compat.IsPortableXaml)
 				Assert.Ignore("Portable.Xaml will convert the types if needed");
-			using (var xr = GetReader ("ArgumentWithIntConstructorFromAttribute.xml")) {
-				var des = (ArgumentWithIntConstructor)XamlServices.Load (xr);
-				Assert.AreEqual (10, des.IntArg, "#2");
+			using (var xr = GetReader("ArgumentWithIntConstructorFromAttribute.xml"))
+			{
+				var des = (ArgumentWithIntConstructor)XamlServices.Load(xr);
+				Assert.AreEqual(10, des.IntArg, "#2");
 			}
 		}
 
 		[Test]
-		public void Write_ArgumentWithIntConstructorFromInt ()
+		public void Write_ArgumentWithIntConstructorFromInt()
 		{
-			using (var xr = GetReader ("ArgumentWithIntConstructorFromInt.xml")) {
-				var des = (ArgumentWithIntConstructor)XamlServices.Load (xr);
-				Assert.AreEqual (11, des.IntArg, "#2");
+			using (var xr = GetReader("ArgumentWithIntConstructorFromInt.xml"))
+			{
+				var des = (ArgumentWithIntConstructor)XamlServices.Load(xr);
+				Assert.AreEqual(11, des.IntArg, "#2");
 			}
 		}
 
 		[Test]
-		public void Write_ArgumentWithIntConstructorFromString ()
+		public void Write_ArgumentWithIntConstructorFromString()
 		{
 			if (!Compat.IsPortableXaml)
 				Assert.Ignore("Portable.Xaml will convert the types if needed");
-			using (var xr = GetReader ("ArgumentWithIntConstructorFromString.xml")) {
-				var des = (ArgumentWithIntConstructor)XamlServices.Load (xr);
-				Assert.AreEqual (12, des.IntArg, "#2");
+			using (var xr = GetReader("ArgumentWithIntConstructorFromString.xml"))
+			{
+				var des = (ArgumentWithIntConstructor)XamlServices.Load(xr);
+				Assert.AreEqual(12, des.IntArg, "#2");
 			}
 		}
 
@@ -1131,7 +1167,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_ArrayExtension2()
 		{
 			//var obj = new ArrayExtension (typeof (int));
-			using (var xr = GetReader ("ArrayExtension2.xml")) {
+			using (var xr = GetReader("ArrayExtension2.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				// The resulting object is not ArrayExtension.
 				Assert.AreEqual(new int[0], des, "#1");
@@ -1142,7 +1179,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_ArrayList()
 		{
 			var obj = new ArrayList(new int[] { 5, -3, 0 });
-			using (var xr = GetReader ("ArrayList.xml")) {
+			using (var xr = GetReader("ArrayList.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				Assert.AreEqual(obj, des, "#1");
 			}
@@ -1151,8 +1189,10 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void ComplexPositionalParameterWrapper()
 		{
-			var ex = Assert.Throws<XamlObjectWriterException> (() => {
-				using (var xr = GetReader ("ComplexPositionalParameterWrapper.xml")) {
+			var ex = Assert.Throws<XamlObjectWriterException>(() =>
+			{
+				using (var xr = GetReader("ComplexPositionalParameterWrapper.xml"))
+				{
 					var des = (ComplexPositionalParameterWrapper)XamlServices.Load(xr);
 					Assert.IsNotNull(des.Param, "#1");
 					Assert.AreEqual("foo", des.Param.Value.Foo, "#2");
@@ -1164,7 +1204,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void ComplexPositionalParameterWrapper2()
 		{
-			using (var xr = GetReader ("ComplexPositionalParameterWrapper2.xml")) {
+			using (var xr = GetReader("ComplexPositionalParameterWrapper2.xml"))
+			{
 				var des = (ComplexPositionalParameterWrapper2)XamlServices.Load(xr);
 				Assert.IsNotNull(des.Param, "#1");
 				Assert.AreEqual("foo", des.Param, "#2");
@@ -1175,7 +1216,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_ListWrapper()
 		{
 			var obj = new ListWrapper(new List<int>(new int[] { 5, -3, 0 }) { Capacity = 3 }); // set explicit capacity for trivial implementation difference
-			using (var xr = GetReader ("ListWrapper.xml")) {
+			using (var xr = GetReader("ListWrapper.xml"))
+			{
 				var des = (ListWrapper)XamlServices.Load(xr);
 				Assert.IsNotNull(des, "#1");
 				Assert.IsNotNull(des.Items, "#2");
@@ -1187,7 +1229,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_ListWrapper2()
 		{
 			var obj = new ListWrapper2(new List<int>(new int[] { 5, -3, 0 }) { Capacity = 3 }); // set explicit capacity for trivial implementation difference
-			using (var xr = GetReader ("ListWrapper2.xml")) {
+			using (var xr = GetReader("ListWrapper2.xml"))
+			{
 				var des = (ListWrapper2)XamlServices.Load(xr);
 				Assert.IsNotNull(des, "#1");
 				Assert.IsNotNull(des.Items, "#2");
@@ -1199,7 +1242,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_MyArrayExtension()
 		{
 			//var obj = new MyArrayExtension (new int [] {5, -3, 0});
-			using (var xr = GetReader ("MyArrayExtension.xml")) {
+			using (var xr = GetReader("MyArrayExtension.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				// ProvideValue() returns an array
 				Assert.AreEqual(new int[] { 5, -3, 0 }, des, "#1");
@@ -1210,7 +1254,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_MyArrayExtensionA()
 		{
 			//var obj = new MyArrayExtensionA (new int [] {5, -3, 0});
-			using (var xr = GetReader ("MyArrayExtensionA.xml")) {
+			using (var xr = GetReader("MyArrayExtensionA.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				// ProvideValue() returns an array
 				Assert.AreEqual(new int[] { 5, -3, 0 }, des, "#1");
@@ -1221,7 +1266,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_MyExtension()
 		{
 			//var obj = new MyExtension () { Foo = typeof (int), Bar = "v2", Baz = "v7"};
-			using (var xr = GetReader ("MyExtension.xml")) {
+			using (var xr = GetReader("MyExtension.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				// ProvideValue() returns this.
 				Assert.AreEqual("provided_value", des, "#1");
@@ -1233,8 +1279,9 @@ namespace MonoTests.Portable.Xaml
 		public void Write_MyExtension2()
 		{
 			//var obj = new MyExtension2 () { Foo = typeof (int), Bar = "v2"};
-			using (var xr = GetReader ("MyExtension2.xml")) {
-				Assert.Throws<InvalidCastException> (() => XamlServices.Load(xr));
+			using (var xr = GetReader("MyExtension2.xml"))
+			{
+				Assert.Throws<InvalidCastException>(() => XamlServices.Load(xr));
 			}
 		}
 
@@ -1242,7 +1289,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_MyExtension3()
 		{
 			//var obj = new MyExtension3 () { Foo = typeof (int), Bar = "v2"};
-			using (var xr = GetReader ("MyExtension3.xml")) {
+			using (var xr = GetReader("MyExtension3.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				// StringConverter is used and the resulting value comes from ToString().
 				Assert.AreEqual("MonoTests.Portable.Xaml.MyExtension3", des, "#1");
@@ -1254,8 +1302,9 @@ namespace MonoTests.Portable.Xaml
 		public void Write_MyExtension4()
 		{
 			var obj = new MyExtension4() { Foo = typeof(int), Bar = "v2" };
-			using (var xr = GetReader ("MyExtension4.xml")) {
-				Assert.Throws<XamlObjectWriterException> (() => XamlServices.Load(xr));
+			using (var xr = GetReader("MyExtension4.xml"))
+			{
+				Assert.Throws<XamlObjectWriterException>(() => XamlServices.Load(xr));
 			}
 		}
 
@@ -1263,7 +1312,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_MyExtension6()
 		{
 			//var obj = new MyExtension6 ("foo");
-			using (var xr = GetReader ("MyExtension6.xml")) {
+			using (var xr = GetReader("MyExtension6.xml"))
+			{
 				var des = XamlServices.Load(xr);
 				// ProvideValue() returns this.
 				Assert.AreEqual("foo", des, "#1");
@@ -1274,7 +1324,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_PropertyDefinition()
 		{
 			//var obj = new PropertyDefinition () { Modifier = "protected", Name = "foo", Type = XamlLanguage.String };
-			using (var xr = GetReader ("PropertyDefinition.xml")) {
+			using (var xr = GetReader("PropertyDefinition.xml"))
+			{
 				var des = (PropertyDefinition)XamlServices.Load(xr);
 				Assert.AreEqual("protected", des.Modifier, "#1");
 				Assert.AreEqual("foo", des.Name, "#2");
@@ -1285,8 +1336,10 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_StaticExtensionWrapper()
 		{
-			var ex = Assert.Throws<XamlObjectWriterException> (() => {
-				using (var xr = GetReader ("StaticExtensionWrapper.xml")) {
+			var ex = Assert.Throws<XamlObjectWriterException>(() =>
+			{
+				using (var xr = GetReader("StaticExtensionWrapper.xml"))
+				{
 #pragma warning disable 219
 					var des = (StaticExtensionWrapper)XamlServices.Load(xr);
 #pragma warning restore 219
@@ -1299,7 +1352,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_StaticExtensionWrapper2()
 		{
-			using (var xr = GetReader ("StaticExtensionWrapper2.xml")) {
+			using (var xr = GetReader("StaticExtensionWrapper2.xml"))
+			{
 				var des = (StaticExtensionWrapper2)XamlServices.Load(xr);
 				Assert.IsNotNull(des.Param, "#1");
 				Assert.AreEqual("foo", des.Param, "#2");
@@ -1309,9 +1363,11 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_TypeExtensionWrapper()
 		{
-			var ex = Assert.Throws<XamlObjectWriterException> (() => {
+			var ex = Assert.Throws<XamlObjectWriterException>(() =>
+			{
 				// can't read a markup extension directly
-				using (var xr = GetReader ("TypeExtensionWrapper.xml")) {
+				using (var xr = GetReader("TypeExtensionWrapper.xml"))
+				{
 #pragma warning disable 219
 					var des = (TypeExtensionWrapper)XamlServices.Load(xr);
 #pragma warning restore 219
@@ -1324,7 +1380,8 @@ namespace MonoTests.Portable.Xaml
 		public void Write_TypeExtensionWrapper2()
 		{
 			//var obj = new TypeExtensionWrapper () { Param = new TypeExtension ("Foo") };
-			using (var xr = GetReader ("TypeExtensionWrapper2.xml")) {
+			using (var xr = GetReader("TypeExtensionWrapper2.xml"))
+			{
 				var des = (TypeExtensionWrapper2)XamlServices.Load(xr);
 				Assert.IsNotNull(des.Param, "#1");
 				Assert.AreEqual(typeof(NamedItem), des.Param, "#2");
@@ -1344,7 +1401,8 @@ namespace MonoTests.Portable.Xaml
 			obj.References.Add(new NamedItem("baz"));
 			obj2.References.Add(obj);
 
-			using (var xr = GetReader ("NamedItems.xml")) {
+			using (var xr = GetReader("NamedItems.xml"))
+			{
 				var des = (NamedItem)XamlServices.Load(xr);
 				Assert.IsNotNull(des, "#1");
 				Assert.AreEqual(2, des.References.Count, "#2");
@@ -1371,7 +1429,8 @@ namespace MonoTests.Portable.Xaml
 			obj2.References.Add(obj3);
 			obj4.References.Add(obj3);
 
-			using (var xr = GetReader ("NamedItems2.xml")) {
+			using (var xr = GetReader("NamedItems2.xml"))
+			{
 				var des = (NamedItem2)XamlServices.Load(xr);
 				Assert.IsNotNull(des, "#1");
 				Assert.AreEqual(2, des.References.Count, "#2");
@@ -1403,7 +1462,8 @@ namespace MonoTests.Portable.Xaml
 			obj2.References.Add(obj3);
 			obj4.References.Add(obj3);
 
-			using (var xr = GetReader ("NamedItems3.xml")) {
+			using (var xr = GetReader("NamedItems3.xml"))
+			{
 				var des = (NamedItem2)XamlServices.Load(xr);
 				Assert.IsNotNull(des, "#1");
 				Assert.AreEqual("i1", des.ItemName, "#2");
@@ -1420,10 +1480,31 @@ namespace MonoTests.Portable.Xaml
 		}
 
 		[Test]
+		public void Write_NamedItems4()
+		{
+			using (var xr = GetReader("NamedItems4.xml"))
+			{
+				var des = (NamedItem2)XamlServices.Load(xr);
+				Assert.IsNotNull(des, "#1");
+				Assert.AreEqual("i1", des.ItemName, "#2");
+				Assert.AreEqual(2, des.References.Count, "#3");
+				Assert.AreEqual(typeof(NamedItem2), des.References[0].GetType(), "#4");
+				Assert.AreEqual(typeof(NamedItem2), des.References[1].GetType(), "#5");
+				Assert.AreEqual("i4", des.References[0].ItemName, "#6");
+				Assert.AreEqual("i2", des.References[1].ItemName, "#7");
+				Assert.AreEqual(1, des.References[0].References.Count, "#8");
+				Assert.AreEqual(1, des.References[1].References.Count, "#9");
+				Assert.AreEqual("i3", des.References[0].References[0].ItemName, "#10");
+				Assert.AreEqual(des.References[0].References[0], des.References[1].References[0], "#11");
+			}
+		}
+
+		[Test]
 		public void Write_XmlSerializableWrapper()
 		{
 			var assns = "clr-namespace:MonoTests.Portable.Xaml;assembly=" + GetType().Assembly.GetName().Name;
-			using (var xr = GetReader ("XmlSerializableWrapper.xml")) {
+			using (var xr = GetReader("XmlSerializableWrapper.xml"))
+			{
 				var des = (XmlSerializableWrapper)XamlServices.Load(xr);
 				Assert.IsNotNull(des, "#1");
 				Assert.IsNotNull(des.Value, "#2");
@@ -1434,7 +1515,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_XmlSerializable()
 		{
-			using (var xr = GetReader ("XmlSerializable.xml")) {
+			using (var xr = GetReader("XmlSerializable.xml"))
+			{
 				var des = (XmlSerializable)XamlServices.Load(xr);
 				Assert.IsNotNull(des, "#1");
 			}
@@ -1443,7 +1525,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_ListXmlSerializable()
 		{
-			using (var xr = GetReader ("List_XmlSerializable.xml")) {
+			using (var xr = GetReader("List_XmlSerializable.xml"))
+			{
 				var des = (List<XmlSerializable>)XamlServices.Load(xr);
 				Assert.AreEqual(1, des.Count, "#1");
 			}
@@ -1452,15 +1535,20 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_AttachedProperty()
 		{
-			using (var xr = GetReader ("AttachedProperty.xml")) {
+			using (var xr = GetReader("AttachedProperty.xml"))
+			{
 				AttachedWrapper des = null;
-				try {
+				try
+				{
 					des = (AttachedWrapper)XamlServices.Load(xr);
 					Assert.IsNotNull(des.Value, "#1");
 					Assert.AreEqual("x", Attachable.GetFoo(des), "#2");
 					Assert.AreEqual("y", Attachable.GetFoo(des.Value), "#3");
-				} finally {
-					if (des != null) {
+				}
+				finally
+				{
+					if (des != null)
+					{
 						Attachable.SetFoo(des, null);
 						Attachable.SetFoo(des.Value, null);
 					}
@@ -1471,7 +1559,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_EventStore()
 		{
-			using (var xr = GetReader ("EventStore.xml")) {
+			using (var xr = GetReader("EventStore.xml"))
+			{
 				var res = (EventStore)XamlServices.Load(xr);
 				Assert.AreEqual("foo", res.Examine(), "#1");
 				Assert.IsTrue(res.Method1Invoked, "#2");
@@ -1482,8 +1571,9 @@ namespace MonoTests.Portable.Xaml
 		// for two occurence of Event1 ...
 		public void Write_EventStore2()
 		{
-			using (var xr = GetReader ("EventStore2.xml")) {
-				Assert.Throws<XamlDuplicateMemberException> (() => XamlServices.Load(xr));
+			using (var xr = GetReader("EventStore2.xml"))
+			{
+				Assert.Throws<XamlDuplicateMemberException>(() => XamlServices.Load(xr));
 			}
 		}
 
@@ -1491,15 +1581,17 @@ namespace MonoTests.Portable.Xaml
 		// attaching nonexistent method
 		public void Write_EventStore3()
 		{
-			using (var xr = GetReader ("EventStore3.xml")) {
-				Assert.Throws<XamlObjectWriterException> (() => XamlServices.Load(xr));
+			using (var xr = GetReader("EventStore3.xml"))
+			{
+				Assert.Throws<XamlObjectWriterException>(() => XamlServices.Load(xr));
 			}
 		}
 
 		[Test]
 		public void Write_EventStore4()
 		{
-			using (var xr = GetReader ("EventStore4.xml")) {
+			using (var xr = GetReader("EventStore4.xml"))
+			{
 				var res = (EventStore2<EventArgs>)XamlServices.Load(xr);
 				Assert.AreEqual("foo", res.Examine(), "#1");
 				Assert.IsTrue(res.Method1Invoked, "#2");
@@ -1509,7 +1601,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_AbstractWrapper()
 		{
-			using (var xr = GetReader ("AbstractContainer.xml")) {
+			using (var xr = GetReader("AbstractContainer.xml"))
+			{
 				var res = (AbstractContainer)XamlServices.Load(xr);
 				Assert.IsNull(res.Value1, "#1");
 				Assert.IsNotNull(res.Value2, "#2");
@@ -1520,7 +1613,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_ReadOnlyPropertyContainer()
 		{
-			using (var xr = GetReader ("ReadOnlyPropertyContainer.xml")) {
+			using (var xr = GetReader("ReadOnlyPropertyContainer.xml"))
+			{
 				var res = (ReadOnlyPropertyContainer)XamlServices.Load(xr);
 				Assert.AreEqual("x", res.Foo, "#1");
 				Assert.AreEqual("x", res.Bar, "#2");
@@ -1530,7 +1624,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_TypeConverterOnListMember()
 		{
-			using (var xr = GetReader ("TypeConverterOnListMember.xml")) {
+			using (var xr = GetReader("TypeConverterOnListMember.xml"))
+			{
 				var res = (SecondTest.TypeOtherAssembly)XamlServices.Load(xr);
 				Assert.AreEqual(3, res.Values.Count, "#1");
 				Assert.AreEqual(3, res.Values[2], "#2");
@@ -1540,7 +1635,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_EnumContainer()
 		{
-			using (var xr = GetReader ("EnumContainer.xml")) {
+			using (var xr = GetReader("EnumContainer.xml"))
+			{
 				var res = (EnumContainer)XamlServices.Load(xr);
 				Assert.AreEqual(EnumValueType.Two, res.EnumProperty, "#1");
 			}
@@ -1549,7 +1645,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_CollectionContentProperty()
 		{
-			using (var xr = GetReader ("CollectionContentProperty.xml")) {
+			using (var xr = GetReader("CollectionContentProperty.xml"))
+			{
 				var res = (CollectionContentProperty)XamlServices.Load(xr);
 				Assert.AreEqual(4, res.ListOfItems.Count, "#1");
 			}
@@ -1558,7 +1655,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_CollectionContentProperty2()
 		{
-			using (var xr = GetReader ("CollectionContentProperty2.xml")) {
+			using (var xr = GetReader("CollectionContentProperty2.xml"))
+			{
 				var res = (CollectionContentProperty)XamlServices.Load(xr);
 				Assert.AreEqual(4, res.ListOfItems.Count, "#1");
 			}
@@ -1567,7 +1665,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_AmbientPropertyContainer()
 		{
-			using (var xr = GetReader ("AmbientPropertyContainer.xml")) {
+			using (var xr = GetReader("AmbientPropertyContainer.xml"))
+			{
 				var res = (SecondTest.ResourcesDict)XamlServices.Load(xr);
 				Assert.AreEqual(2, res.Count, "#1");
 				Assert.IsTrue(res.ContainsKey("TestDictItem"), "#2");
@@ -1582,7 +1681,8 @@ namespace MonoTests.Portable.Xaml
 		[Test] // bug #682102
 		public void Write_AmbientPropertyContainer2()
 		{
-			using (var xr = GetReader ("AmbientPropertyContainer2.xml")) {
+			using (var xr = GetReader("AmbientPropertyContainer2.xml"))
+			{
 				var res = (SecondTest.ResourcesDict)XamlServices.Load(xr);
 				Assert.AreEqual(2, res.Count, "#1");
 				Assert.IsTrue(res.ContainsKey("TestDictItem"), "#2");
@@ -1597,7 +1697,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_NullableContainer()
 		{
-			using (var xr = GetReader ("NullableContainer.xml")) {
+			using (var xr = GetReader("NullableContainer.xml"))
+			{
 				var res = (NullableContainer)XamlServices.Load(xr);
 				Assert.AreEqual(5, res.TestProp, "#1");
 			}
@@ -1606,7 +1707,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_DirectListContainer()
 		{
-			using (var xr = GetReader ("DirectListContainer.xml")) {
+			using (var xr = GetReader("DirectListContainer.xml"))
+			{
 				var res = (DirectListContainer)XamlServices.Load(xr);
 				Assert.AreEqual(3, res.Items.Count, "#1");
 				Assert.AreEqual("Hello3", res.Items[2].Value, "#2");
@@ -1616,7 +1718,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_DirectDictionaryContainer()
 		{
-			using (var xr = GetReader ("DirectDictionaryContainer.xml")) {
+			using (var xr = GetReader("DirectDictionaryContainer.xml"))
+			{
 				var res = (DirectDictionaryContainer)XamlServices.Load(xr);
 				Assert.AreEqual(3, res.Items.Count, "#1");
 				Assert.AreEqual(40, res.Items[EnumValueType.Three], "#2");
@@ -1626,7 +1729,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_DirectDictionaryContainer2()
 		{
-			using (var xr = GetReader ("DirectDictionaryContainer2.xml")) {
+			using (var xr = GetReader("DirectDictionaryContainer2.xml"))
+			{
 				var res = (SecondTest.ResourcesDict2)XamlServices.Load(xr);
 				Assert.AreEqual(2, res.Count, "#1");
 				Assert.AreEqual("1", ((SecondTest.TestObject2)res["1"]).TestProperty, "#2");
@@ -1637,7 +1741,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_NullableWithConverter()
 		{
-			using (var xr = GetReader ("NullableWithConverter.xml")) {
+			using (var xr = GetReader("NullableWithConverter.xml"))
+			{
 				var res = (NullableWithTypeConverterContainer)XamlServices.Load(xr);
 				Assert.IsNotNull(res.TestProp, "#1");
 				Assert.AreEqual("SomeText", res.TestProp.Value.Text, "#2");
@@ -1647,7 +1752,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_DeferredLoadingContainerMember()
 		{
-			using (var xr = GetReader ("DeferredLoadingContainerMember.xml")) {
+			using (var xr = GetReader("DeferredLoadingContainerMember.xml"))
+			{
 				var res = (DeferredLoadingContainerMember)XamlServices.Load(xr);
 				Assert.IsNotNull(res, "#1");
 				Assert.IsNotNull(res.Child, "#2");
@@ -1665,7 +1771,8 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_DeferredLoadingContainerType()
 		{
-			using (var xr = GetReader ("DeferredLoadingContainerType.xml")) {
+			using (var xr = GetReader("DeferredLoadingContainerType.xml"))
+			{
 				var res = (DeferredLoadingContainerType)XamlServices.Load(xr);
 				Assert.IsNotNull(res, "#1");
 				Assert.IsNotNull(res.Child, "#2");
@@ -1683,15 +1790,17 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Write_DeferredLoadingWithInvalidType()
 		{
-			using (var xr = GetReader ("DeferredLoadingWithInvalidType.xml")) {
-				Assert.Throws<XamlSchemaException> (() => XamlServices.Load(xr));
+			using (var xr = GetReader("DeferredLoadingWithInvalidType.xml"))
+			{
+				Assert.Throws<XamlSchemaException>(() => XamlServices.Load(xr));
 			}
 		}
 
 		[Test]
 		public void Write_DeferredLoadingContainerMemberStringType()
 		{
-			using (var xr = GetReader ("DeferredLoadingContainerMemberStringType.xml")) {
+			using (var xr = GetReader("DeferredLoadingContainerMemberStringType.xml"))
+			{
 				var res = (DeferredLoadingContainerMemberStringType)XamlServices.Load(xr);
 				Assert.IsNotNull(res, "#1");
 				Assert.IsNotNull(res.Child, "#2");
@@ -1705,6 +1814,30 @@ namespace MonoTests.Portable.Xaml
 				Assert.AreEqual("Blah", ((DeferredLoadingChild)obj).Foo, "#8");
 			}
 		}
+
+#if !PCL136
+		[Test]
+		public void Write_ImmutableTypeWithNames()
+		{
+			if (!Compat.IsPortableXaml)
+				Assert.Ignore("Not supported in System.Xaml");
+
+			using (var xr = GetReader("ImmutableTypeWithNames.xml"))
+			{
+				var res = (NamedItem3)XamlServices.Load(xr);
+
+				Assert.IsNotNull(res);
+				Assert.AreEqual(2, res.ImmutableReferences.Length);
+				Assert.AreEqual("i4", res.ImmutableReferences[0].ItemName);
+				Assert.AreEqual(3, res.ImmutableReferences[0].ImmutableReferences.Length);
+				Assert.AreEqual("i3", res.ImmutableReferences[0].ImmutableReferences[0].ItemName);
+				Assert.AreEqual("i5", res.ImmutableReferences[0].ImmutableReferences[1].ItemName);
+				Assert.AreEqual("i1", res.ImmutableReferences[0].ImmutableReferences[2].ItemName);
+				Assert.AreEqual("i1", res.ImmutableReferences[0].Other.ItemName);
+
+			}
+		}
+#endif
 
 		[Test]
 		[Category(Categories.NotOnSystemXaml)]

--- a/src/Test/XmlFiles/ImmutableTypeWithNames.xml
+++ b/src/Test/XmlFiles/ImmutableTypeWithNames.xml
@@ -1,0 +1,24 @@
+<NamedItem3 xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sci="clr-namespace:System.Collections.Immutable;assembly=System.Collections.Immutable">
+  <NamedItem3.ImmutableReferences>
+    <sci:ImmutableArray x:TypeArguments="NamedItem3">
+      <NamedItem3 x:Name="i4">
+        <NamedItem3.ImmutableReferences>
+          <sci:ImmutableArray x:TypeArguments="NamedItem3">
+            <x:Reference>i3</x:Reference>
+            <NamedItem3 x:Name="i5" />
+            <x:Reference>i1</x:Reference>
+          </sci:ImmutableArray>
+        </NamedItem3.ImmutableReferences>
+        <NamedItem3.Other>
+          <x:Reference>i1</x:Reference>
+        </NamedItem3.Other>
+      </NamedItem3>
+      <NamedItem3 x:Name="i2">
+        <NamedItem3.ImmutableReferences>
+          <NamedItem3 x:Name="i3" />
+        </NamedItem3.ImmutableReferences>
+      </NamedItem3>
+    </sci:ImmutableArray>
+  </NamedItem3.ImmutableReferences>
+  <NamedItem3.ItemName>i1</NamedItem3.ItemName>
+</NamedItem3>

--- a/src/Test/XmlFiles/NamedItems4.xml
+++ b/src/Test/XmlFiles/NamedItems4.xml
@@ -1,0 +1,14 @@
+<NamedItem2 x:Name="i1" xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <NamedItem2.References>
+    <NamedItem2 x:Name="i4">
+      <NamedItem2.References>
+        <x:Reference>i3</x:Reference>
+      </NamedItem2.References>
+    </NamedItem2>
+    <NamedItem2 x:Name="i2">
+      <NamedItem2.References>
+        <NamedItem2 x:Name="i3" />
+      </NamedItem2.References>
+    </NamedItem2>
+  </NamedItem2.References>
+</NamedItem2>


### PR DESCRIPTION
- Fix order of items in a collection when using x:Reference
- Don’t serialize empty/default immutable collections to xaml to keep it clean
- Add XamlMemberInvoker.IsDefaultValue() virtual method so you can override how xaml determines if an object is the default value, which is needed for immutable objects.