### PR TITLE
More massive performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ This is intended to be used to read and write Xaml on desktop, mobile, and .NET 
 
 Portable.Xaml currently supports the following profiles:
 
-- Profile 259 - For .NET 4.5, .NET Core, WinRT, Xamarin, etc.
-- Profile 136 - For .NET 4.0 support
+- .NET Standard 1.3 - For .NET 4.6, .NET Core, UWP, Xamarin, etc.
+- Profile 259 - For .NET 4.5
+- Profile 136 - For .NET 4.0
 
 Other profiles can be contributed if desired, but these should support the widest range of platforms.
 
@@ -24,7 +25,7 @@ To get daily builds, add the [appveyor feed](https://ci.appveyor.com/nuget/porta
 
 The goal of this library is not necessarily to replicate the functionality of System.Xaml going forward, so breaking changes may occur, but only when necessary to keep migrating to Portable.Xaml straightforward.
 
-The main difference between this and System.Xaml is that it comes with its own (minimal) `TypeConverter` implementation as the PCL profiles do not support them. To hook into the existing `System.ComponentModel.TypeConverter` on platforms that support it, a shim can be added [to be documented].
+The main difference between this and System.Xaml is that it comes with its own (minimal) `TypeConverter` implementation for the PCL profiles as they do not support them. To hook into the existing `System.ComponentModel.TypeConverter` on platforms that support it, a shim can be added [to be documented].
 
 Some of the enhanced functionality of Portable.Xaml include (but not limited to):
 
@@ -42,28 +43,26 @@ Contributors are more than welcome! Ideally this library can become well support
 
 ## Performance
 
-What about performance you ask? Portable.Xaml can actually be faster than .NET's System.Xaml in most cases, especially when loading xaml.
-
-Portable.Xaml's performance has also been drastically improved over mono's initial implementation by 11x loading, and 28x saving.
+What about performance you ask? Portable.Xaml's performance has been drastically improved over mono's initial implementation, and is actually much faster than .NET's System.Xaml in most cases.
 
 Here's some results using [BenchmarkDotNet](http://benchmarkdotnet.org):
 
 ### Load
-| Method |          Mean |      StdDev | Scaled | Scaled-StdDev |    Gen 0 | Allocated |
-|-------------------- |-------------- |------------ |------- |-------------- |--------- |---------- |
-|        PortableXaml |   691.6986 us |   9.8060 us |   1.00 |          0.00 |        - |  72.21 kB |
-|          SystemXaml | 1,289.9520 us |   5.8708 us |   1.87 |          0.03 |        - | 155.19 kB |
-| PortableXamlNoCache | 1,603.6102 us |  10.8539 us |   2.32 |          0.03 |        - | 130.45 kB |
-|   SystemXamlNoCache | 1,859.4895 us |  34.3770 us |   2.69 |          0.06 |        - | 188.29 kB |
-|            OmniXaml | 8,505.1863 us | 158.3414 us |  12.30 |          0.28 | 164.5833 |   1.73 MB |
-
+|              Method |       Mean |     StdDev |    Op/s | Scaled |    Gen 0 |  Allocated |
+|-------------------- |-----------:|-----------:|--------:|-------:|---------:|-----------:|
+|        PortableXaml |   569.8 us |  16.294 us | 1,754.9 |   1.00 |  11.7188 |   50.56 KB |
+|          SystemXaml | 1,325.2 us |  11.485 us |   754.6 |   2.33 |  35.1563 |  151.53 KB |
+| PortableXamlNoCache | 1,409.3 us |   7.649 us |   709.6 |   2.48 |  25.3906 |  106.38 KB |
+|   SystemXamlNoCache | 1,892.2 us |  28.304 us |   528.5 |   3.32 |  44.9219 |  184.67 KB |
+|   OmniXamlBenchmark | 8,095.5 us | 310.062 us |   123.5 |  14.22 | 406.2500 | 1689.29 KB |
+      
 ### Save
-| Method |          Mean |     StdDev | Scaled | Scaled-StdDev |   Gen 0 | Allocated |
-|-------------------- |-------------- |----------- |------- |-------------- |-------- |---------- |
-|        PortableXaml |   813.9052 us | 11.2787 us |   1.00 |          0.00 |       - | 146.18 kB |
-|          SystemXaml |   874.2129 us | 15.8162 us |   1.07 |          0.02 |       - | 120.03 kB |
-| PortableXamlNoCache | 1,588.3347 us |  9.7873 us |   1.95 |          0.03 | 15.6250 | 197.46 kB |
-|   SystemXamlNoCache | 1,187.0039 us | 13.3269 us |   1.46 |          0.03 |       - | 142.01 kB |
+|              Method |       Mean |    StdDev |    Op/s | Scaled |   Gen 0 | Allocated |
+|-------------------- |-----------:|----------:|--------:|-------:|--------:|----------:|
+|        PortableXaml |   481.8 us |  2.805 us | 2,075.4 |   1.00 | 26.8555 |  110.4 KB |
+|          SystemXaml |   809.2 us | 12.997 us | 1,235.8 |   1.68 | 28.3203 |  117.2 KB |
+| PortableXamlNoCache | 1,060.2 us | 34.809 us |   943.3 |   2.20 | 33.2031 | 138.91 KB |
+|   SystemXamlNoCache | 1,151.5 us | 18.052 us |   868.5 |   2.39 | 33.2031 | 139.17 KB |
 
 ## License
 

--- a/src/Portable.Xaml.Benchmark/LoadBenchmark.cs
+++ b/src/Portable.Xaml.Benchmark/LoadBenchmark.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using BenchmarkDotNet.Attributes;
 using System.Collections.Generic;
 using System.IO;
@@ -8,7 +8,6 @@ using System.Diagnostics;
 
 namespace Portable.Xaml.Benchmark
 {
-	[Config(typeof(Config))]
 	public abstract class LoadBenchmark : IXamlBenchmark
 	{
 		public abstract string TestName { get; }

--- a/src/Portable.Xaml.Benchmark/Portable.Xaml.Benchmark.csproj
+++ b/src/Portable.Xaml.Benchmark/Portable.Xaml.Benchmark.csproj
@@ -9,7 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Portable.Xaml.Benchmark</RootNamespace>
     <AssemblyName>Portable.Xaml.Benchmark</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <BaseIntermediateOutputPath>..\..\artifacts\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -32,9 +32,30 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BenchmarkDotNet, Version=0.10.6.0, Culture=neutral, PublicKeyToken=aa0ca2f9092cefc4, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.0.10.6\lib\net46\BenchmarkDotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="BenchmarkDotNet.Core, Version=0.10.6.0, Culture=neutral, PublicKeyToken=aa0ca2f9092cefc4, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.Core.0.10.6\lib\net46\BenchmarkDotNet.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="BenchmarkDotNet.Toolchains.Roslyn, Version=0.10.6.0, Culture=neutral, PublicKeyToken=aa0ca2f9092cefc4, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.Toolchains.Roslyn.0.10.6\lib\net46\BenchmarkDotNet.Toolchains.Roslyn.dll</HintPath>
+    </Reference>
     <Reference Include="Glass.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Glass.Core.2.0.0\lib\netstandard1.2\Glass.Core.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.2.1.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.DotNet.InternalAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.DotNet.InternalAbstractions.1.0.0\lib\net451\Microsoft.DotNet.InternalAbstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=1.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.1.1.2\lib\net451\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
     </Reference>
     <Reference Include="OmniXaml, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\OmniXaml.2.0.0\lib\netstandard1.2\OmniXaml.dll</HintPath>
@@ -49,16 +70,19 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.3.0\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Serilog.2.3.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Sprache, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Sprache.2.1.0\lib\net40\Sprache.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.Primitives, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -69,38 +93,78 @@
       <HintPath>..\packages\System.ComponentModel.TypeConverter.4.3.0\lib\net45\System.ComponentModel.TypeConverter.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.3.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.FileVersionInfo, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.FileVersionInfo.4.3.0\lib\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.StackTrace, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.StackTrace.4.3.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.2\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.0.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="BenchmarkDotNet.Core">
-      <HintPath>..\packages\BenchmarkDotNet.Core.0.10.1\lib\net45\BenchmarkDotNet.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System.Management" />
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
-    <Reference Include="BenchmarkDotNet.Toolchains.Roslyn">
-      <HintPath>..\packages\BenchmarkDotNet.Toolchains.Roslyn.0.10.1\lib\net45\BenchmarkDotNet.Toolchains.Roslyn.dll</HintPath>
-    </Reference>
-    <Reference Include="BenchmarkDotNet">
-      <HintPath>..\packages\BenchmarkDotNet.0.10.1\lib\net45\BenchmarkDotNet.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XmlDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XmlDocument.4.3.0\lib\net46\System.Xml.XmlDocument.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XPath, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.4.3.0\lib\net46\System.Xml.XPath.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XPath.XDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.XDocument.4.3.0\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/src/Portable.Xaml.Benchmark/Program.cs
+++ b/src/Portable.Xaml.Benchmark/Program.cs
@@ -7,41 +7,31 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Columns;
 
 namespace Portable.Xaml.Benchmark
 {
-	class Config : ManualConfig
-	{
-		public Config()
-		{
-			/* doesn't work yet, still runs twice as of BenchmarkDotNet 0.10.1
-			Add(Job.Dry
-				.With(RunStrategy.ColdStart)
-				.WithLaunchCount(4)
-				.WithId("ColdStart")
-				);
-			*/
-			
-			Add(Job.Default);
-		}
-	}
-
 	class MainClass
 	{
 		public static void Main(string[] args)
 		{
-			/**  Uncomment to test using performance profiler *
-			
-			//var benchmark = new LoadSimpleBenchmark();
-			var benchmark = new LoadComplexBenchmark();
-			//var benchmark = new SaveSimpleBenchmark();
-			//var benchmark = new SaveComplexBenchmark();
-			for (int i = 0; i < 10000; i++)
+			/**  Uncomment to test using performance profiler */
+			if (args?.FirstOrDefault() == "profile")
 			{
-				benchmark.PortableXaml();
-				//b.SystemXaml();
+				//var benchmark = new LoadSimpleBenchmark();
+				var benchmark = new LoadComplexBenchmark();
+				//var benchmark = new SaveSimpleBenchmark();
+				//var benchmark = new SaveComplexBenchmark();
+				for (int i = 0; i < 1000; i++)
+				{
+					benchmark.PortableXaml();
+					//benchmark.PortableXamlNoCache();
+					//benchmark.SystemXaml();
+					//benchmark.SystemXamlNoCache();
+				}
+				return;
 			}
-			return;
 			/**/
 
 			// BenchmarkSwitcher doesn't automatically exclude abstract benchmark classes
@@ -50,8 +40,16 @@ namespace Portable.Xaml.Benchmark
 				.GetExportedTypes()
 				.Where(r => typeof(IXamlBenchmark).IsAssignableFrom(r) && !r.IsAbstract);
 
+
+			var config = ManualConfig
+				.Create(DefaultConfig.Instance)
+				.With(Job.Default)
+				.With(MemoryDiagnoser.Default)
+				.With(StatisticColumn.OperationsPerSecond)
+				.With(RankColumn.Arabic);
+
 			var switcher = new BenchmarkSwitcher(types.ToArray());
-			switcher.Run(args);
+			switcher.Run(args, config);
 		}
 	}
 }

--- a/src/Portable.Xaml.Benchmark/app.config
+++ b/src/Portable.Xaml.Benchmark/app.config
@@ -1,11 +1,67 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" /></startup>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.ComponentModel.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Algorithms" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.FileVersionInfo" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.DotNet.PlatformAbstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Portable.Xaml.Benchmark/packages.config
+++ b/src/Portable.Xaml.Benchmark/packages.config
@@ -1,38 +1,48 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BenchmarkDotNet" version="0.10.1" targetFramework="net45" />
-  <package id="BenchmarkDotNet.Core" version="0.10.1" targetFramework="net45" />
-  <package id="BenchmarkDotNet.Toolchains.Roslyn" version="0.10.1" targetFramework="net45" />
+  <package id="BenchmarkDotNet" version="0.10.6" targetFramework="net461" />
+  <package id="BenchmarkDotNet.Core" version="0.10.6" targetFramework="net461" />
+  <package id="BenchmarkDotNet.Toolchains.Roslyn" version="0.10.6" targetFramework="net461" />
   <package id="Glass.Core" version="2.0.0" targetFramework="net451" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.1.0" targetFramework="net461" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.1.0" targetFramework="net461" />
+  <package id="Microsoft.DotNet.InternalAbstractions" version="1.0.0" targetFramework="net461" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="1.1.2" targetFramework="net461" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net451" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net451" />
   <package id="OmniXaml" version="2.0.0" targetFramework="net451" />
   <package id="OmniXaml.Attributes" version="2.0.0" targetFramework="net451" />
   <package id="OmniXaml.Services" version="2.0.0" targetFramework="net451" />
-  <package id="Serilog" version="2.3.0" targetFramework="net451" />
+  <package id="Serilog" version="2.3.0" targetFramework="net461" />
   <package id="Sprache" version="2.1.0" targetFramework="net451" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections" version="4.3.0" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net451" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net461" />
   <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net451" />
   <package id="System.ComponentModel.TypeConverter" version="4.3.0" targetFramework="net451" />
+  <package id="System.Console" version="4.3.0" targetFramework="net461" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net451" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.3.1" targetFramework="net461" />
+  <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.StackTrace" version="4.3.0" targetFramework="net461" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net451" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net451" />
+  <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net461" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net451" />
   <package id="System.IO" version="4.3.0" targetFramework="net451" />
-  <package id="System.IO.Compression" version="4.3.0" targetFramework="net451" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq" version="4.3.0" targetFramework="net451" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net451" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net451" />
+  <package id="System.Net.Http" version="4.3.2" targetFramework="net461" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net451" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net451" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net451" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net451" />
-  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net461" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net451" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net451" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net451" />
@@ -40,13 +50,24 @@
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net451" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net451" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net451" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net451" />
+  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net461" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net451" />
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net451" />
   <package id="System.Threading" version="4.3.0" targetFramework="net451" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net451" />
-  <package id="System.Threading.Tasks.Extensions" version="4.0.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net451" />
-  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net451" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net461" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net461" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net451" />
+  <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net461" />
+  <package id="System.Xml.XPath" version="4.3.0" targetFramework="net461" />
+  <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/src/Portable.Xaml/Portable.Xaml-netstandard1.3.csproj
+++ b/src/Portable.Xaml/Portable.Xaml-netstandard1.3.csproj
@@ -12,9 +12,10 @@
     <DefineConstants>TRACE;DEBUG;NETSTANDARD1_3;PCL;NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType></DebugType>
+    <DebugType>pdbonly</DebugType>
     <OutputPath>..\..\artifacts\Release\</OutputPath>
     <DefineConstants>TRACE;RELEASE;NETSTANDARD1_3;PCL;NETSTANDARD</DefineConstants>
+    <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />

--- a/src/Portable.Xaml/Portable.Xaml.Schema/XamlMemberInvoker.cs
+++ b/src/Portable.Xaml/Portable.Xaml.Schema/XamlMemberInvoker.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -54,7 +54,7 @@ namespace Portable.Xaml.Schema
 
 		public XamlMemberInvoker(XamlMember member)
 		{
-			if (member == null)
+			if (ReferenceEquals(member, null))
 				throw new ArgumentNullException("member");
 			Member = member;
 		}
@@ -70,12 +70,20 @@ namespace Portable.Xaml.Schema
 				return getDelegate(instance);
 			}
 
-			if (Member == null)
+			if (ReferenceEquals(Member, null))
 				throw new NotSupportedException("Current operation is invalid for unknown member.");
 
 			if (Member.IsDirective)
 				throw new NotSupportedException($"not supported operation on directive member {Member}");
 
+			CreateGetDelegate();
+
+			return getDelegate(instance);
+		}
+
+		void CreateGetDelegate()
+		{
+			// this is in a separate method since this makes the GetValue() method allocate an internal anonymous class
 			var getter = UnderlyingGetter;
 			if (getter == null)
 				throw new NotSupportedException($"Attempt to get value from write-only property or event {Member}");
@@ -83,21 +91,23 @@ namespace Portable.Xaml.Schema
 			var mode = Member.SchemaContext.InvokerOptions;
 			if (mode.HasFlag(XamlInvokerOptions.DeferCompile))
 			{
-				getDelegate = i => getter.Invoke(i, null);
-				Task.Factory.StartNew(() => getDelegate = getter.BuildGetExpression());
+				getDelegate = GetValueReflection;
+				Task.Factory.StartNew(BuildGetExpression);
 			}
 			else if (mode.HasFlag(XamlInvokerOptions.Compile))
 			{
+				//Console.WriteLine($"Building getter for {getter}");
 				getDelegate = getter.BuildGetExpression();
 			}
 			else
 			{
-				getDelegate = i => getter.Invoke(i, null);
+				getDelegate = GetValueReflection;
 			}
-
-
-			return getDelegate(instance);
 		}
+
+		object GetValueReflection(object instance) => UnderlyingGetter.Invoke(instance, null);
+
+		void BuildGetExpression() => getDelegate = UnderlyingGetter.BuildGetExpression();
 
 		public virtual void SetValue(object instance, object value)
 		{
@@ -111,12 +121,19 @@ namespace Portable.Xaml.Schema
 				return;
 			}
 
-			if (Member == null)
+			if (ReferenceEquals(Member, null))
 				throw new NotSupportedException("Current operation is invalid for unknown member.");
 
 			if (Member.IsDirective)
 				throw new NotSupportedException($"not supported operation on directive member {Member}");
 
+			CreateSetDelegate();
+
+			setDelegate(instance, value);
+		}
+
+		void CreateSetDelegate()
+		{
 			var setter = UnderlyingSetter;
 			if (setter == null)
 				throw new NotSupportedException($"Attempt to set value from read-only property {Member}");
@@ -125,7 +142,7 @@ namespace Portable.Xaml.Schema
 			if (mode.HasFlag(XamlInvokerOptions.DeferCompile))
 			{
 				CreateSetDelegate(setter);
-				Task.Factory.StartNew(() => setDelegate = setter.BuildCallExpression());
+				Task.Factory.StartNew(BuildSetterExpression);
 			}
 			else if (mode.HasFlag(XamlInvokerOptions.Compile))
 			{
@@ -135,16 +152,26 @@ namespace Portable.Xaml.Schema
 			{
 				CreateSetDelegate(setter);
 			}
-
-			setDelegate(instance, value);
 		}
+
+		void BuildSetterExpression() => setDelegate = UnderlyingSetter.BuildCallExpression();
 
 		void CreateSetDelegate(MethodInfo setter)
 		{
 			if (Member.IsAttachable)
-				setDelegate = (i, v) => setter.Invoke(null, new object[] { i, v });
+				setDelegate = SetDelegateReflectionAttachable;
 			else
-				setDelegate = (i, v) => setter.Invoke(i, new object[] { v });
+				setDelegate = SetDelegateReflection;
+		}
+
+		void SetDelegateReflectionAttachable(object instance, object value)
+		{
+			UnderlyingSetter.Invoke(null, new object[] { instance, value });
+		}
+
+		void SetDelegateReflection(object instance, object value)
+		{
+			UnderlyingSetter.Invoke(instance, new object[] { value });
 		}
 
 		public virtual ShouldSerializeResult ShouldSerializeValue(object instance)

--- a/src/Portable.Xaml/Portable.Xaml.Schema/XamlTypeName.cs
+++ b/src/Portable.Xaml/Portable.Xaml.Schema/XamlTypeName.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -198,9 +198,10 @@ namespace Portable.Xaml.Schema
 			Namespace = xamlType.PreferredXamlNamespace;
 			Name = xamlType.Name;
 			if (xamlType.TypeArguments != null && xamlType.TypeArguments.Count > 0) {
-				var l = new List<XamlTypeName> ();
-				l.AddRange (from x in xamlType.TypeArguments select new XamlTypeName (x));
-				TypeArguments = l;
+				TypeArguments = xamlType
+					.TypeArguments
+					.Select(x => new XamlTypeName (x))
+					.ToList();
 			}
 		}
 		
@@ -232,7 +233,7 @@ namespace Portable.Xaml.Schema
 			return ToString (null);
 		}
 
-		public string ToString (INamespacePrefixLookup prefixLookup)
+		public string ToString(INamespacePrefixLookup prefixLookup)
 		{
 			if (Namespace == null)
 				throw new InvalidOperationException ("Namespace must be set before calling ToString method.");

--- a/src/Portable.Xaml/Portable.Xaml/XamlDirective.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlDirective.cs
@@ -54,7 +54,7 @@ namespace Portable.Xaml
 		{
 			if (xamlNamespaces == null)
 				throw new ArgumentNullException ("xamlNamespaces");
-			if (xamlType == null)
+			if (ReferenceEquals(xamlType, null))
 				throw new ArgumentNullException ("xamlType");
 
 			type = xamlType;
@@ -76,8 +76,8 @@ namespace Portable.Xaml
 
 		public override int GetHashCode ()
 		{
-			var name = string.IsNullOrEmpty(PreferredXamlNamespace) ? Name : PreferredXamlNamespace;
-			return name.GetHashCode();
+			var pns = PreferredXamlNamespace ?? string.Empty;
+			return pns.GetHashCode() ^ Name.GetHashCode();
 		}
 
 		public override IList<string> GetXamlNamespaces ()

--- a/src/Portable.Xaml/Portable.Xaml/XamlNameResolver.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlNameResolver.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -146,7 +146,7 @@ namespace Portable.Xaml
 			// generate a name for it, only when needed.
 			var xm = xobj.Type.GetAliasedProperty (XamlLanguage.Name);
 			if (xm != null)
-				name = (string) xm.Invoker.GetValue (xobj.RawValue);
+				name = (string) xm.Invoker.GetValue (xobj.Value);
 			else
 				name = "__ReferenceID" + used_reference_ids++;
 			un.Name = name;

--- a/src/Portable.Xaml/Portable.Xaml/XamlNodeListReader.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlNodeListReader.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -53,7 +53,7 @@ namespace Portable.Xaml
 
 		public override XamlMember Member
 		{
-			get { return NodeType == XamlNodeType.StartMember ? node.Member.Member : null; }
+			get { return NodeType == XamlNodeType.StartMember ? node.Member : null; }
 		}
 
 		public override NamespaceDeclaration Namespace

--- a/src/Portable.Xaml/Portable.Xaml/XamlNodeListWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlNodeListWriter.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -43,7 +43,7 @@ namespace Portable.Xaml
 
 		public override void WriteEndMember ()
 		{
-			source.Add (new XamlNodeInfo (XamlNodeType.EndMember, default (XamlNodeMember)));
+			source.Add (new XamlNodeInfo (XamlNodeType.EndMember, default (XamlMember)));
 		}
 
 		public override void WriteEndObject ()
@@ -63,7 +63,7 @@ namespace Portable.Xaml
 
 		public override void WriteStartMember (XamlMember xamlMember)
 		{
-			source.Add (new XamlNodeInfo (XamlNodeType.StartMember, new XamlNodeMember (default (XamlObject), xamlMember)));
+			source.Add (new XamlNodeInfo (XamlNodeType.StartMember, xamlMember));
 		}
 
 		public override void WriteStartObject (XamlType type)

--- a/src/Portable.Xaml/Portable.Xaml/XamlNodeQueueReader.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlNodeQueueReader.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2011 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -42,7 +42,7 @@ namespace Portable.Xaml
 		public override bool IsEof => (node.Node?.NodeType ?? XamlNodeType.None) == XamlNodeType.None;
 		//public override bool IsEof => node.Node.NodeType == XamlNodeType.None;
 
-		public override XamlMember Member => NodeType != XamlNodeType.StartMember ? null : node.Node.Member.Member;
+		public override XamlMember Member => NodeType != XamlNodeType.StartMember ? null : node.Node.Member;
 
 		public override NamespaceDeclaration Namespace => NodeType != XamlNodeType.NamespaceDeclaration ? null : (NamespaceDeclaration) node.Node.Value;
 

--- a/src/Portable.Xaml/Portable.Xaml/XamlNodeQueueWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlNodeQueueWriter.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2011 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -43,7 +43,7 @@ namespace Portable.Xaml
 
 		public override void WriteEndMember ()
 		{
-			source.Enqueue (new XamlNodeInfo (XamlNodeType.EndMember, default (XamlNodeMember)));
+			source.Enqueue (new XamlNodeInfo (XamlNodeType.EndMember, default (XamlMember)));
 		}
 
 		public override void WriteEndObject ()
@@ -63,7 +63,7 @@ namespace Portable.Xaml
 
 		public override void WriteStartMember (XamlMember xamlMember)
 		{
-			source.Enqueue (new XamlNodeInfo (XamlNodeType.StartMember, new XamlNodeMember (default (XamlObject), xamlMember)));
+			source.Enqueue (new XamlNodeInfo (XamlNodeType.StartMember, xamlMember));
 		}
 
 		public override void WriteStartObject (XamlType type)

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectReader.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectReader.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -123,7 +123,7 @@ namespace Portable.Xaml
 		// - For IXmlSerializable, it does not either return the raw IXmlSerializable or interpreted XData (it just returns null).
 		public virtual object Instance {
 			get {
-				var cur = NodeType == XamlNodeType.StartObject ? nodes.Current.Object.RawValue : null;
+				var cur = NodeType == XamlNodeType.StartObject ? nodes.Current.Object.Value : null;
 				return cur == root ? root_raw : cur is XData ? null : cur;
 			}
 		}
@@ -133,7 +133,7 @@ namespace Portable.Xaml
 		}
 
 		public override XamlMember Member {
-			get { return NodeType == XamlNodeType.StartMember ? nodes.Current.Member.Member : null; }
+			get { return NodeType == XamlNodeType.StartMember ? nodes.Current.Member : null; }
 		}
 
 		public override NamespaceDeclaration Namespace {

--- a/src/Portable.Xaml/Portable.Xaml/XamlParseException.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlParseException.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -42,6 +42,11 @@ namespace Portable.Xaml
 
 		public XamlParseException (string message, Exception innerException)
 			: base (message, innerException)
+		{
+		}
+
+		internal XamlParseException(string message, Exception innerException, int lineNumber, int linePosition)
+			: base(message, innerException, lineNumber, linePosition)
 		{
 		}
 

--- a/src/Portable.Xaml/Portable.Xaml/XamlReader.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlReader.cs
@@ -22,6 +22,7 @@
 //
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Portable.Xaml
 {
@@ -59,13 +60,43 @@ namespace Portable.Xaml
 			return new XamlSubtreeReader(this);
 		}
 
-#if NETSTANDARD
-		/* For debugging */
-		public void Dump()
+#if DEBUG
+		/* For debugging purposes */
+		[EnhancedXaml]
+		public void Dump(Action<string> write)
 		{
+			var sb = new StringBuilder();
 			while (Read())
 			{
-				Console.WriteLine($"{NodeType}: Type: {Type}, Member: {Member}, Value: {Value}");
+				sb.Clear();
+				sb.Append(NodeType);
+				sb.Append(": ");
+				if (Type != null)
+				{
+					sb.Append(" Type:");
+					sb.Append(Type);
+				}
+				if (Member != null)
+				{
+					sb.Append(" Member:");
+					sb.Append(Member);
+				}
+				if (Namespace != null)
+				{
+					sb.Append(" Namespace:");
+					if (Namespace.Prefix != null)
+					{
+						sb.Append(Namespace.Prefix);
+						sb.Append(":");
+					}
+					sb.Append(Namespace.Namespace);
+				}
+				if (!ReferenceEquals(Value, null))
+				{
+					sb.Append(" Value:");
+					sb.Append(Value);
+				}
+				write(sb.ToString());
 			}
 		}
 #endif

--- a/src/Portable.Xaml/Portable.Xaml/XamlServices.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlServices.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -94,9 +94,10 @@ namespace Portable.Xaml
 				Save (xw, instance);
 		}
 
+		static XamlSchemaContextSettings s_settings = new XamlSchemaContextSettings { InvokerOptions = XamlInvokerOptions.None };
 		public static void Save (XmlWriter xmlWriter, object instance)
 		{
-			Save (new XamlXmlWriter (xmlWriter, new XamlSchemaContext ()), instance);
+			Save (new XamlXmlWriter (xmlWriter, new XamlSchemaContext(s_settings)), instance);
 		}
 
 		public static void Save (XamlWriter xamlWriter, object instance)

--- a/src/Portable.Xaml/Portable.Xaml/XamlWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriter.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -59,6 +59,9 @@ namespace Portable.Xaml
 				throw new ArgumentNullException ("reader");
 
 			switch (reader.NodeType) {
+			case XamlNodeType.Value:
+				WriteValue (reader.Value);
+				break;
 			case XamlNodeType.StartObject:
 				WriteStartObject (reader.Type);
 				break;
@@ -73,9 +76,6 @@ namespace Portable.Xaml
 				break;
 			case XamlNodeType.EndMember:
 				WriteEndMember ();
-				break;
-			case XamlNodeType.Value:
-				WriteValue (reader.Value);
 				break;
 			case XamlNodeType.NamespaceDeclaration:
 				WriteNamespace (reader.Namespace);

--- a/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 // Copyright (C) 2012 Xamarin Inc. http://xamarin.com
 //
@@ -43,12 +43,12 @@ namespace Portable.Xaml
 {
 	abstract class XamlWriterInternalBase : IProvideValueTarget, IRootObjectProvider, IDestinationTypeProvider, IAmbientProvider
 	{
-		protected XamlWriterInternalBase (XamlSchemaContext schemaContext, XamlWriterStateManager manager)
+		protected XamlWriterInternalBase(XamlSchemaContext schemaContext, XamlWriterStateManager manager)
 		{
 			this.sctx = schemaContext;
 			this.manager = manager;
-			var p = new PrefixLookup (sctx) { IsCollectingNamespaces = true }; // it does not raise unknown namespace error.
-			service_provider = new ValueSerializerContext (p, schemaContext, this, this, this, this, this as IXamlObjectWriterFactory);
+			var p = new PrefixLookup(sctx) { IsCollectingNamespaces = true }; // it does not raise unknown namespace error.
+			service_provider = new ValueSerializerContext(p, schemaContext, this, this, this, this, this as IXamlObjectWriterFactory);
 		}
 
 		internal XamlSchemaContext sctx;
@@ -57,10 +57,10 @@ namespace Portable.Xaml
 		internal ValueSerializerContext service_provider;
 
 		internal ObjectState root_state;
-		internal Stack<ObjectState> object_states = new Stack<ObjectState> ();
-		internal PrefixLookup prefix_lookup => (PrefixLookup) service_provider.GetService (typeof (INamespacePrefixLookup));
+		internal Stack<ObjectState> object_states = new Stack<ObjectState>();
+		internal PrefixLookup prefix_lookup => (PrefixLookup)service_provider.GetService(typeof(INamespacePrefixLookup));
 
-		public Type GetDestinationType () => CurrentMember?.Type.UnderlyingType;
+		public Type GetDestinationType() => CurrentMember?.Type.UnderlyingType;
 
 		List<NamespaceDeclaration> Namespaces => prefix_lookup.Namespaces;
 
@@ -69,15 +69,38 @@ namespace Portable.Xaml
 		internal class ObjectState
 		{
 			public XamlType Type;
-			public bool IsGetObject;
+			FlagValue _flags;
+			static class ObjectStateFlags
+			{
+				public const int IsGetObject = 1 << 0;
+				public const int IsInstantiated = 1 << 1;
+				public const int IsXamlWriterCreated = 1 << 2;
+			}
+
+			public bool IsGetObject
+			{
+				get { return _flags.Get(ObjectStateFlags.IsGetObject) ?? false; }
+				set { _flags.Set(ObjectStateFlags.IsGetObject, value); }
+			}
+			public bool IsInstantiated
+			{
+				get { return _flags.Get(ObjectStateFlags.IsInstantiated) ?? false; }
+				set { _flags.Set(ObjectStateFlags.IsInstantiated, value); }
+			}
+			public bool IsXamlWriterCreated // affects AfterProperties() calls.
+			{
+				get { return _flags.Get(ObjectStateFlags.IsXamlWriterCreated) ?? false; }
+				set { _flags.Set(ObjectStateFlags.IsXamlWriterCreated, value); }
+			}
+
 			public int PositionalParameterIndex = -1;
 
 			public string FactoryMethod;
 			public object Value;
 			public object KeyValue;
-			public List<MemberAndValue> WrittenProperties = new List<MemberAndValue> ();
-			public bool IsInstantiated;
-			public bool IsXamlWriterCreated; // affects AfterProperties() calls.
+			public List<MemberAndValue> WrittenProperties = new List<MemberAndValue>();
+
+			public XamlMember CurrentMember => CurrentMemberState?.Member;
 
 			public MemberAndValue CurrentMemberState
 			{
@@ -93,7 +116,7 @@ namespace Portable.Xaml
 
 		internal class MemberAndValue
 		{
-			public MemberAndValue (XamlMember xm)
+			public MemberAndValue(XamlMember xm)
 			{
 				Member = xm;
 			}
@@ -103,27 +126,29 @@ namespace Portable.Xaml
 			public AllowedMemberLocations OccuredAs = AllowedMemberLocations.None;
 		}
 
-		public void CloseAll ()
+		public virtual void CloseAll()
 		{
-			while (object_states.Count > 0) {
-				switch (manager.State) {
-				case XamlWriteState.MemberDone:
-				case XamlWriteState.ObjectStarted: // StartObject without member
-					WriteEndObject ();
-					break;
-				case XamlWriteState.ValueWritten:
-				case XamlWriteState.ObjectWritten:
-				case XamlWriteState.MemberStarted: // StartMember without content
-					manager.OnClosingItem ();
-					WriteEndMember ();
-					break;
-				default:
-					throw new NotImplementedException (manager.State.ToString ()); // there shouldn't be anything though
+			while (object_states.Count > 0)
+			{
+				switch (manager.State)
+				{
+					case XamlWriteState.MemberDone:
+					case XamlWriteState.ObjectStarted: // StartObject without member
+						WriteEndObject();
+						break;
+					case XamlWriteState.ValueWritten:
+					case XamlWriteState.ObjectWritten:
+					case XamlWriteState.MemberStarted: // StartMember without content
+						manager.OnClosingItem();
+						WriteEndMember();
+						break;
+					default:
+						throw new NotImplementedException(manager.State.ToString()); // there shouldn't be anything though
 				}
 			}
 		}
 
-		internal string GetPrefix (string ns)
+		internal string GetPrefix(string ns)
 		{
 			foreach (var nd in Namespaces)
 				if (nd.Namespace == ns)
@@ -131,146 +156,156 @@ namespace Portable.Xaml
 			return null;
 		}
 
-		protected MemberAndValue CurrentMemberState {
+		protected ObjectState CurrentState => object_states.Count > 0 ? object_states.Peek() : null;
+		protected MemberAndValue CurrentMemberState => CurrentState?.CurrentMemberState;
+		protected XamlMember CurrentMember => CurrentMemberState?.Member;
+
+		protected XamlMember LastMember => LastState?.CurrentMemberState?.Member;
+		protected ObjectState LastState
+		{
 			get
 			{
-				if (object_states.Count > 0)
+				if (object_states.Count > 1)
 				{
-					return object_states.Peek().CurrentMemberState;
+					var state = object_states.Pop();
+					var last = object_states.Peek();
+					object_states.Push(state);
+					return last;
 				}
 				return null;
 			}
+
 		}
 
-		protected XamlMember CurrentMember => CurrentMemberState?.Member;
-
-		public void WriteGetObject ()
+		public void WriteGetObject()
 		{
-			manager.GetObject ();
+			manager.GetObject();
 
 			var xm = CurrentMember;
 
-			var state = new ObjectState () {Type = xm.Type, IsGetObject = true};
+			var state = new ObjectState() { Type = xm.Type, IsGetObject = true };
 
-			object_states.Push (state);
+			object_states.Push(state);
 
-			OnWriteGetObject ();
+			OnWriteGetObject();
 		}
 
-		public void WriteNamespace (NamespaceDeclaration namespaceDeclaration)
+		public void WriteNamespace(NamespaceDeclaration namespaceDeclaration)
 		{
 			if (namespaceDeclaration == null)
-				throw new ArgumentNullException ("namespaceDeclaration");
+				throw new ArgumentNullException("namespaceDeclaration");
 
-			manager.Namespace ();
+			manager.Namespace();
 
-			Namespaces.Add (namespaceDeclaration);
-			OnWriteNamespace (namespaceDeclaration);
+			Namespaces.Add(namespaceDeclaration);
+			OnWriteNamespace(namespaceDeclaration);
 		}
 
-		public void WriteStartObject (XamlType xamlType)
+		public void WriteStartObject(XamlType xamlType)
 		{
-			if (xamlType == null)
-				throw new ArgumentNullException ("xamlType");
+			if (ReferenceEquals(xamlType, null))
+				throw new ArgumentNullException("xamlType");
 
-			manager.StartObject ();
-			var cstate = new ObjectState () {Type = xamlType};
-			object_states.Push (cstate);
+			manager.StartObject();
+			var cstate = new ObjectState() { Type = xamlType };
+			object_states.Push(cstate);
 
-			OnWriteStartObject ();
+			OnWriteStartObject();
 		}
-		
-		public void WriteValue (object value)
-		{
-			manager.Value ();
 
-			OnWriteValue (value);
+		public void WriteValue(object value)
+		{
+			manager.Value();
+
+			OnWriteValue(value);
 		}
-		
-		public void WriteStartMember (XamlMember property)
-		{
-			if (property == null)
-				throw new ArgumentNullException ("property");
 
-			manager.StartMember ();
-			if (property == XamlLanguage.PositionalParameters)
+		public void WriteStartMember(XamlMember property)
+		{
+			if (ReferenceEquals(property, null))
+				throw new ArgumentNullException("property");
+
+			manager.StartMember();
+			if (ReferenceEquals(property, XamlLanguage.PositionalParameters))
 				// this is an exception that indicates the state manager to accept more than values within this member.
 				manager.AcceptMultipleValues = true;
 
-			var state = object_states.Peek ();
+			var state = object_states.Peek();
 			var wpl = state.WrittenProperties;
-			foreach (var wp in wpl)
+			for (int i = 0; i < wpl.Count; i++)
 			{
-				if (wp.Member == property)
+				var wp = wpl[i];
+				if (ReferenceEquals(wp.Member, property))
 					throw new XamlDuplicateMemberException(String.Format("Property '{0}' is already set to this '{1}' object", property, object_states.Peek().Type));
 			}
 
-			wpl.Add (new MemberAndValue (property));
-			if (property == XamlLanguage.PositionalParameters)
+			wpl.Add(new MemberAndValue(property));
+			if (ReferenceEquals(property, XamlLanguage.PositionalParameters))
 				state.PositionalParameterIndex = 0;
 
-			OnWriteStartMember (property);
+			OnWriteStartMember(property);
 
 		}
-		
-		public void WriteEndObject ()
+
+		public void WriteEndObject()
 		{
-			manager.EndObject (object_states.Count > 1);
+			manager.EndObject(object_states.Count > 1);
 
-			OnWriteEndObject ();
+			OnWriteEndObject();
 
-			object_states.Pop ();
+			object_states.Pop();
 		}
 
-		public void WriteEndMember ()
+		public void WriteEndMember()
 		{
 
-			manager.EndMember ();
+			manager.EndMember();
 
-			OnWriteEndMember ();
-			
-			var state = object_states.Peek ();
-			if (CurrentMember == XamlLanguage.PositionalParameters) {
+			OnWriteEndMember();
+
+			var state = object_states.Peek();
+			if (ReferenceEquals(CurrentMember, XamlLanguage.PositionalParameters))
+			{
 				manager.AcceptMultipleValues = false;
 				state.PositionalParameterIndex = -1;
 			}
 		}
 
-		protected abstract void OnWriteEndObject ();
+		protected abstract void OnWriteEndObject();
 
-		protected abstract void OnWriteEndMember ();
+		protected abstract void OnWriteEndMember();
 
-		protected abstract void OnWriteStartObject ();
+		protected abstract void OnWriteStartObject();
 
-		protected abstract void OnWriteGetObject ();
+		protected abstract void OnWriteGetObject();
 
-		protected abstract void OnWriteStartMember (XamlMember xm);
+		protected abstract void OnWriteStartMember(XamlMember xm);
 
-		protected abstract void OnWriteValue (object value);
+		protected abstract void OnWriteValue(object value);
 
-		protected abstract void OnWriteNamespace (NamespaceDeclaration nd);
-		
-		protected string GetValueString (XamlMember xm, object value)
+		protected abstract void OnWriteNamespace(NamespaceDeclaration nd);
+
+		protected string GetValueString(XamlMember xm, object value)
 		{
 			// change XamlXmlReader too if we change here.
 			if ((value as string) == String.Empty) // FIXME: there could be some escape syntax.
 				return "\"\"";
 			if (value is string)
-				return (string) value;
+				return (string)value;
 
-			var xt = value == null ? XamlLanguage.Null : sctx.GetXamlType (value.GetType ());
+			var xt = value == null ? XamlLanguage.Null : sctx.GetXamlType(value.GetType());
 			var vs = xm.ValueSerializer ?? xt.ValueSerializer;
 			if (vs != null)
-				return vs.ConverterInstance.ConvertToString (value, service_provider);
+				return vs.ConverterInstance.ConvertToString(value, service_provider);
 			else
-				throw new XamlXmlWriterException (String.Format ("Value type is '{0}' but it must be either string or any type that is convertible to string indicated by TypeConverterAttribute.", value != null ? value.GetType () : null));
+				throw new XamlXmlWriterException(String.Format("Value type is '{0}' but it must be either string or any type that is convertible to string indicated by TypeConverterAttribute.", value != null ? value.GetType() : null));
 		}
 
-#region IAmbientProvider
+		#region IAmbientProvider
 
 		public IEnumerable<object> GetAllAmbientValues(params XamlType[] types)
 		{
-			return GetAllAmbientValues (null, false, types).Select(r => r.Value);
+			return GetAllAmbientValues(null, false, types).Select(r => r.Value);
 		}
 
 		public IEnumerable<AmbientPropertyValue> GetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, params XamlMember[] properties)
@@ -326,6 +361,6 @@ namespace Portable.Xaml
 		{
 			return GetAllAmbientValues(ceilingTypes, properties).FirstOrDefault();
 		}
-#endregion
+		#endregion
 	}
 }

--- a/src/Portable.Xaml/Portable.Xaml/XamlXmlWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlXmlWriter.cs
@@ -87,12 +87,8 @@ namespace Portable.Xaml
 		
 		public XamlXmlWriter (XmlWriter xmlWriter, XamlSchemaContext schemaContext, XamlXmlWriterSettings settings)
 		{
-			if (xmlWriter == null)
-				throw new ArgumentNullException ("xmlWriter");
-			if (schemaContext == null)
-				throw new ArgumentNullException ("schemaContext");
-			this.w = xmlWriter;
-			this.sctx = schemaContext;
+			this.w = xmlWriter ?? throw new ArgumentNullException(nameof(xmlWriter));
+			this.sctx = schemaContext ?? throw new ArgumentNullException(nameof(schemaContext));
 			this.settings = settings ?? new XamlXmlWriterSettings ();
 			var manager = new XamlWriterStateManager<XamlXmlWriterException, InvalidOperationException> (true);
 			intl = new XamlXmlWriterInternal (xmlWriter, sctx, manager);

--- a/src/Test/Compat.cs
+++ b/src/Test/Compat.cs
@@ -51,6 +51,14 @@ namespace MonoTests.Portable.Xaml
 		public static Type GetTypeInfo(this Type type) => type;
 #endif
 
+#if PCL136
+		public static Assembly GetAssembly(this Type type) => type.Assembly;
+		public static bool GetIsGenericType(this Type type) => type.IsGenericType;
+#else
+		public static Assembly GetAssembly(this Type type) => type.GetTypeInfo().Assembly;
+		public static bool GetIsGenericType(this Type type) => type.GetTypeInfo().IsGenericType;
+#endif
+
 		public static string UpdateXml(this string str)
 		{
 			return str.Replace("net_4_0", Compat.Version)
@@ -62,7 +70,18 @@ namespace MonoTests.Portable.Xaml
 				.Replace("\n", Environment.NewLine);
 		}
 
-        public static bool IsMono
+		public static string UpdateJson(this string str)
+		{
+			return str.Replace("net_4_0", Compat.Version)
+				.Replace("net_4_5", Compat.Version)
+				.Replace("clr-namespace:Portable.Xaml;assembly=Portable.Xaml", $"clr-namespace:{Compat.Namespace};assembly={Compat.Namespace}")
+				.Replace($" px:", $" {Compat.Prefix}:")
+				.Replace($"$ns:px", $"$ns:{Compat.Prefix}")
+				.Replace("\r", "")
+				.Replace("\n", Environment.NewLine);
+		}
+
+		public static bool IsMono
         {
             get { return Type.GetType("Mono.Runtime", false) != null; }
         }
@@ -71,7 +90,7 @@ namespace MonoTests.Portable.Xaml
 		{
 			return Path.Combine (
 #if !WINDOWS_UWP
-				Path.GetDirectoryName (typeof(Compat).GetTypeInfo().Assembly.Location),
+				Path.GetDirectoryName (typeof(Compat).GetAssembly().Location),
 #endif
 				"XmlFiles",
 				fileName);

--- a/src/Test/Portable.Xaml-tests-net_4_5.csproj
+++ b/src/Test/Portable.Xaml-tests-net_4_5.csproj
@@ -111,7 +111,6 @@
   <ItemGroup>
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>

--- a/src/Test/Portable.Xaml-tests-netstandard1.3.csproj
+++ b/src/Test/Portable.Xaml-tests-netstandard1.3.csproj
@@ -108,12 +108,12 @@
     </PostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
@@ -132,10 +132,10 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="XmlFiles\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Test/System.Xaml/XamlObjectReaderTest.cs
+++ b/src/Test/System.Xaml/XamlObjectReaderTest.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -375,22 +375,24 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Read_XData()
 		{
-			if (!Compat.IsPortableXaml)
-				Assert.Ignore(".NET does not support this");
-			var r = new XamlObjectReader(new XData() { Text = "xdata text" });
-			while (!r.IsEof)
-				r.Read();
+			Assert.Throws<XamlObjectReaderException>(() =>
+			{
+				var r = new XamlObjectReader(new XData() { Text = "xdata text" });
+				while (!r.IsEof)
+					r.Read();
+			});
 		}
 
 		[Test]
 		public void Read_XDataWrapper()
 		{
-			if (!Compat.IsPortableXaml)
-				Assert.Ignore(".NET does not support this");
-			var obj = new XDataWrapper() { Markup = new XData() { Text = "<my_xdata/>" } };
-			var r = new XamlObjectReader(obj);
-			while (!r.IsEof)
-				r.Read();
+			Assert.Throws<XamlObjectReaderException>(() =>
+			{
+				var obj = new XDataWrapper() { Markup = new XData() { Text = "<my_xdata/>" } };
+				var r = new XamlObjectReader(obj);
+				while (!r.IsEof)
+					r.Read();
+			});
 		}
 
 		[Test]

--- a/src/Test/packages.config
+++ b/src/Test/packages.config
@@ -1,8 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.6.1" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net462" />
-  <package id="System.Collections.NonGeneric" version="4.3.0" targetFramework="net462" />
-  <package id="System.ComponentModel.Primitives" version="4.3.0" targetFramework="net462" />
-  <package id="System.ComponentModel.TypeConverter" version="4.3.0" targetFramework="net462" />
+  <package id="NUnit" version="3.6.1" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
This mainly focuses on improving writing speed, but had an effect on reading quite drastically as well.

- Large improvements in memory and performance of saving xaml
- Eliminate as many enumerator allocations as possible
- Reduce object allocations in general
- Compare XamlType/XamlMember with directives or null using ReferenceEquals