### PR TITLE
Properly write base class properties when they are in a different namespace

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlMember.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlMember.cs
@@ -179,6 +179,15 @@ namespace Portable.Xaml
 			flags.Set(MemberFlags.IsAttachable, isAttachable);
 		}
 
+		internal XamlMember(string name, string preferredNamespace)
+		{
+			if (name == null)
+				throw new ArgumentNullException("name");
+			Name = name;
+			flags.Set(MemberFlags.IsUnknown, true);
+			ns.Set(preferredNamespace);
+		}
+
 		XamlMember(XamlSchemaContext schemaContext, XamlMemberInvoker invoker)
 		{
 			if (schemaContext == null)
@@ -322,7 +331,7 @@ namespace Portable.Xaml
 					return String.Concat(DeclaringType.UnderlyingType.FullName, ".", Name);
 			}
 			else
-				return String.Concat("{", PreferredXamlNamespace, "}", DeclaringType.Name, ".", Name);
+				return String.Concat("{", PreferredXamlNamespace, "}", DeclaringType?.Name, ".", Name);
 		}
 
 		public virtual IList<string> GetXamlNamespaces()

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -418,6 +418,8 @@ namespace Portable.Xaml
 			// FIXME: this condition needs to be examined. What is known to be prevented are: PositionalParameters, Initialization and Base (the last one sort of indicates there's a lot more).
 			else
 			{
+				if (property.IsUnknown)
+					throw new XamlObjectWriterException($"Cannot set unknown member '{property}'");
 				if (!property.IsDirective || ReferenceEquals(property, XamlLanguage.Name)) // x:Name requires an object instance
 					InitializeObjectIfRequired(false);
 			}

--- a/src/Portable.Xaml/Portable.Xaml/XamlXmlReader.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlXmlReader.cs
@@ -346,7 +346,7 @@ namespace Portable.Xaml
 				}
 
 				// creates name-only XamlType. Also, it does not seem that it does not store this XamlType to XamlSchemaContext (Try GetXamlType(xtn) after reading such xaml node, it will return null).
-				xt = new XamlType (sti.Namespace, sti.Name, sti.TypeName.TypeArguments == null ? null : sti.TypeName.TypeArguments.Select<XamlTypeName,XamlType> (xxtn => sctx.GetXamlType (xxtn)).ToArray (), sctx);
+				xt = new XamlType (sti.Namespace, sti.Name, sti.TypeName.TypeArguments?.Select(xxtn => sctx.GetXamlType (xxtn)).ToArray (), sctx);
 			}
 
 			// It could still be GetObject if current_member
@@ -536,8 +536,8 @@ namespace Portable.Xaml
 								atts.Add(new StringPair(r.Name, r.Value));
 								continue;
 							}
-							// Should we just ignore unknown attribute in XAML namespace or any other namespaces ?
-							// Probably yes for compatibility with future version.
+							// System.Xaml does not ignore attributes with namespaces
+							members.Add(new Pair(new XamlMember(r.LocalName, r.NamespaceURI), r.Value));
 							break;
 					}
 				} while (r.MoveToNextAttribute());
@@ -583,7 +583,9 @@ namespace Portable.Xaml
 				var xm = xt.GetMember(name);
 				if (xm != null)
 					sti.Members.Add(new Pair(xm, p.Value));
-				// ignore unknown attribute
+				else
+					// unknown attributes go through!
+					sti.Members.Add(new Pair(new XamlMember(name, xt, false), p.Value));
 			}
 		}
 

--- a/src/Portable.Xaml/Portable.Xaml/XamlXmlWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlXmlWriter.cs
@@ -417,22 +417,24 @@ namespace Portable.Xaml
 		void OnWriteStartMemberElement (XamlType xt, XamlMember xm)
 		{
 			CurrentMemberState.OccuredAs = AllowedMemberLocations.MemberElement;
-			string prefix = GetPrefix (xm.PreferredXamlNamespace);
+			var ns = xm.IsAttachable || xm.IsDirective ? xm.PreferredXamlNamespace : xt.PreferredXamlNamespace;
+			string prefix = GetPrefix (ns);
 			string name = xm.IsDirective ? xm.Name : String.Concat (xt.InternalXmlName, ".", xm.Name);
 			WritePendingNamespaces ();
-			w.WriteStartElement (prefix, name, xm.PreferredXamlNamespace);
+			w.WriteStartElement (prefix, name, ns);
 		}
 		
 		void OnWriteStartMemberAttribute (XamlType xt, XamlMember xm)
 		{
 			CurrentMemberState.OccuredAs = AllowedMemberLocations.Attribute;
+			var ns = xm.IsAttachable || xm.IsDirective ? xm.PreferredXamlNamespace : xt.PreferredXamlNamespace;
 			string name = xm.GetInternalXmlName ();
-			if (xt.PreferredXamlNamespace == xm.PreferredXamlNamespace &&
-			    !(xm is XamlDirective)) // e.g. x:Key inside x:Int should not be written as Key.
+			if (xt.PreferredXamlNamespace == ns &&
+			    !xm.IsDirective) // e.g. x:Key inside x:Int should not be written as Key.
 				w.WriteStartAttribute (name);
 			else {
-				string prefix = GetPrefix (xm.PreferredXamlNamespace);
-				w.WriteStartAttribute (prefix, name, xm.PreferredXamlNamespace);
+				string prefix = GetPrefix (ns);
+				w.WriteStartAttribute (prefix, name, ns);
 			}
 		}
 

--- a/src/Test/System.Windows.Markup/ValueSerializerTest.cs
+++ b/src/Test/System.Windows.Markup/ValueSerializerTest.cs
@@ -97,6 +97,10 @@ namespace MonoTests.Portable.Xaml.Markup
 				// What is funny or annoying here is, that always return true for CanConvertToString() while everything fails at ConvertToString() on .NET.
 				if (t.UnderlyingType == typeof(string))
 					continue;
+#if NETSTANDARD
+				if (t.UnderlyingType == typeof(Uri))
+					continue;
+#endif
 
 				int i = 0;
 				foreach (var val in test_values)

--- a/src/Test/System.Windows.Markup/XamlDeferLoadTest.cs
+++ b/src/Test/System.Windows.Markup/XamlDeferLoadTest.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -48,7 +48,7 @@ namespace MonoTests.Portable.Xaml.Markup
 		[TestCase("something", null)]
 		[TestCase(null, "something")]
 		[TestCase(null, null)]
-		public void ConstructorNullName (string loaderType, string contentType)
+		public void ConstructorNullNameString (string loaderType, string contentType)
 		{
 			Assert.Throws<ArgumentNullException> (() => new XamlDeferLoadAttribute(loaderType, contentType));
 		}
@@ -57,7 +57,7 @@ namespace MonoTests.Portable.Xaml.Markup
 		[TestCase(typeof(TestDeferredLoader), null)]
 		[TestCase(null, typeof(DeferredLoadingChild))]
 		[TestCase(null, null)]
-		public void ConstructorNullName (Type loaderType, Type contentType)
+		public void ConstructorNullNameType (Type loaderType, Type contentType)
 		{
 			Assert.Throws<ArgumentNullException> (() => new XamlDeferLoadAttribute(loaderType, contentType));
 		}

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -104,6 +104,14 @@ namespace MonoTests.Portable.Xaml.NamespaceTest
 	}
 }
 
+namespace MonoTests.Portable.Xaml.NamespaceTest2
+{
+	public class TestClassWithDifferentBaseNamespace : MonoTests.Portable.Xaml.TestClass5WithName
+	{
+		public string SomeOtherProperty { get; set; }
+	}
+}
+
 namespace MonoTests.Portable.Xaml
 {
 
@@ -344,6 +352,16 @@ namespace MonoTests.Portable.Xaml
 	public class TestClass6
 	{
 		public DateTime TheDateAndTime { get; set; }
+	}
+
+	[RuntimeNameProperty("TheName")]
+	public class TestClass5WithName : TestClass5
+	{
+		[sc.DefaultValue(null)]
+		public string TheName { get; set; }
+
+		[sc.DefaultValue(null)]
+		public TestClass5WithName Other { get; set; }
 	}
 
 	public class TestClassBase

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2054,5 +2054,14 @@ namespace MonoTests.Portable.Xaml
 				Assert.AreEqual ("4", des.Contents [3].Foo, "#5");
 			}
 		}
+
+		[Test]
+		public void Read_InvalidPropertiesShouldThrowException()
+		{
+			Assert.Throws<XamlObjectWriterException>(() =>
+			{
+				XamlServices.Load(GetReader("InvalidPropertiesShouldThrowException.xml"));
+			});
+		}
 	}
 }

--- a/src/Test/System.Xaml/XamlReaderTestBase.cs
+++ b/src/Test/System.Xaml/XamlReaderTestBase.cs
@@ -3925,7 +3925,7 @@ if (i == 0) {
             Assert.AreEqual(XamlNodeType.EndMember, r.NodeType, "ebase#2");
         }
 
-		void ReadNamespace (XamlReader r, string prefix, string ns, string label)
+		protected void ReadNamespace (XamlReader r, string prefix, string ns, string label)
 		{
 			Assert.IsTrue (r.Read (), label + "-1");
 			Assert.AreEqual (XamlNodeType.NamespaceDeclaration, r.NodeType, label + "-2");
@@ -3934,7 +3934,7 @@ if (i == 0) {
 			Assert.AreEqual (ns, r.Namespace.Namespace, label + "-5");
 		}
 
-		void ReadMemberWithValue (XamlReader r, XamlMember member, string label, params object[] values)
+		protected void ReadMemberWithValue (XamlReader r, XamlMember member, string label, params object[] values)
 		{
 			ReadMember(r, member, label, () => {
 				for (int i = 0; i < values.Length; i++)
@@ -3944,7 +3944,7 @@ if (i == 0) {
 			});
 		}
 
-		void ReadObject(XamlReader r, XamlType type, string label, Action readContent = null)
+		protected void ReadObject(XamlReader r, XamlType type, string label, Action readContent = null)
 		{
 			Assert.IsTrue(r.Read(), "so#1-1");
 			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType, "so#1-2");
@@ -3957,14 +3957,14 @@ if (i == 0) {
 			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType, "eo#1-2");
 		}
 
-		void ReadValue(XamlReader r, object value, string label)
+		protected void ReadValue(XamlReader r, object value, string label)
 		{
 			Assert.IsTrue(r.Read(), label + "-1");
 			Assert.AreEqual(XamlNodeType.Value, r.NodeType, label + "-2");
 			Assert.AreEqual(value, r.Value, label + "-3");
 		}
 
-		void ReadMember (XamlReader r, XamlMember member, string label, Action readContent = null)
+		protected void ReadMember (XamlReader r, XamlMember member, string label, Action readContent = null)
 		{
 			Assert.IsTrue(r.Read(), label + "-1");
 			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType, label + "-2");

--- a/src/Test/System.Xaml/XamlTypeTest.cs
+++ b/src/Test/System.Xaml/XamlTypeTest.cs
@@ -916,6 +916,25 @@ namespace MonoTests.Portable.Xaml
 			Assert.IsInstanceOf<global::Portable.Xaml.ComponentModel.DateTimeConverter>(xt.TypeConverter.ConverterInstance, "#4");
 #endif
 		}
+
+		[Test]
+		public void BaseClassPropertiesShouldHaveProperNamespaces()
+		{
+			var xtnamebase = sctx.GetXamlType(typeof(TestClass5WithName));
+			var xtderived = sctx.GetXamlType(typeof(NamespaceTest2.TestClassWithDifferentBaseNamespace));
+			Assert.IsNotNull(xtderived);
+			var xmname = xtderived.GetMember("TheName");
+			Assert.IsNotNull(xmname);
+			Assert.AreSame(xtnamebase, xmname.TargetType);
+			Assert.AreSame(xtnamebase, xmname.DeclaringType);
+			// note that the preferred namespace of the name member does not reflect the type we got the 
+			// member from, but the type it is declared on.
+			Assert.AreEqual(xtnamebase.PreferredXamlNamespace, xmname.PreferredXamlNamespace);
+
+			Assert.AreSame(xmname, xtderived.GetAliasedProperty(XamlLanguage.Name));
+			// not important: Assert.AreNotSame(xmname, xtnamebase.GetAliasedProperty(XamlLanguage.Name));
+			Assert.AreEqual(xmname, xtnamebase.GetAliasedProperty(XamlLanguage.Name));
+		}
 	}
 
 	class MyXamlType : XamlType

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -56,6 +56,12 @@ namespace MonoTests.Portable.Xaml
 			return new XamlXmlReader(new StringReader(xml), new XamlSchemaContext(), settings);
 		}
 
+		XamlReader GetReaderText(string xml, XamlXmlReaderSettings settings = null)
+		{
+			xml = xml.UpdateXml();
+			return new XamlXmlReader(new StringReader(xml), new XamlSchemaContext(), settings);
+		}
+
 		void ReadTest(string filename)
 		{
 			var r = GetReader(filename);
@@ -1012,5 +1018,75 @@ namespace MonoTests.Portable.Xaml
 			Assert.AreEqual(234567, obj.LongValue, "#7");
 		}
 
+		[Test]
+		public void Read_BaseClassPropertiesInSeparateNamespace()
+		{
+			var obj = (NamespaceTest2.TestClassWithDifferentBaseNamespace)XamlServices.Load(GetReader("BaseClassPropertiesInSeparateNamespace.xml"));
+			Assert.IsNotNull(obj);
+			Assert.AreEqual("MyName", obj.TheName);
+			Assert.AreEqual("OtherValue", obj.SomeOtherProperty);
+			Assert.AreEqual("TheBar", obj.Bar);
+			Assert.IsNull(obj.Baz);
+		}
+
+		[Test]
+		public void Read_BaseClassPropertiesInSeparateNamespace_WithChildren()
+		{
+			var obj = (NamespaceTest2.TestClassWithDifferentBaseNamespace)XamlServices.Load(GetReader("BaseClassPropertiesInSeparateNamespace_WithChildren.xml"));
+			Assert.IsNotNull(obj);
+			Assert.AreEqual("MyName", obj.TheName);
+			Assert.AreEqual("OtherValue", obj.SomeOtherProperty);
+			Assert.AreEqual("TheBar", obj.Bar);
+			Assert.IsNull(obj.Baz);
+			Assert.IsNotNull(obj.Other);
+			Assert.AreEqual("TheBar2", obj.Other.Bar);
+		}
+
+		[Test]
+		public void Read_InvalidPropertiesShouldBeRead()
+		{
+			var xaml = @"<TestClassWithDifferentBaseNamespace UnknownProperty=""Woo"" xmlns=""urn:mono-test2""/>";
+			var reader = GetReaderText(xaml);
+			Assert.IsTrue(reader.Read());
+			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, reader.NodeType);
+			Assert.AreEqual("urn:mono-test2", reader.Namespace.Namespace);
+
+			XamlType xt;
+			Assert.IsTrue(reader.Read());
+			Assert.AreEqual(XamlNodeType.StartObject, reader.NodeType);
+			Assert.AreEqual(xt = reader.SchemaContext.GetXamlType(typeof(MonoTests.Portable.Xaml.NamespaceTest2.TestClassWithDifferentBaseNamespace)), reader.Type);
+
+			ReadBase(reader);
+
+			Assert.IsTrue(reader.Read());
+			Assert.AreEqual(XamlNodeType.StartMember, reader.NodeType);
+			Assert.AreEqual("UnknownProperty", reader.Member.Name);
+			Assert.IsTrue(reader.Member.IsUnknown);
+		}
+
+		[Test]
+		public void Read_InvalidPropertiesShouldBeRead2()
+		{
+			var xaml = @"<TestClassWithDifferentBaseNamespace base:UnknownProperty=""Woo"" xmlns=""urn:mono-test2"" xmlns:base=""clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml-tests-net_4_5""/>";
+			var reader = GetReaderText(xaml);
+
+			ReadNamespace(reader, string.Empty, "urn:mono-test2", "");
+
+			var ns = "clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml-tests-net_4_5".UpdateXml();
+			ReadNamespace(reader, "base", ns, "");
+
+			XamlType xt;
+			Assert.IsTrue(reader.Read());
+			Assert.AreEqual(XamlNodeType.StartObject, reader.NodeType);
+			Assert.AreEqual(xt = reader.SchemaContext.GetXamlType(typeof(MonoTests.Portable.Xaml.NamespaceTest2.TestClassWithDifferentBaseNamespace)), reader.Type);
+
+			ReadBase(reader);
+
+			Assert.IsTrue(reader.Read());
+			Assert.AreEqual(XamlNodeType.StartMember, reader.NodeType);
+			Assert.AreEqual("UnknownProperty", reader.Member.Name);
+			Assert.AreEqual(ns, reader.Member.PreferredXamlNamespace);
+			Assert.IsTrue(reader.Member.IsUnknown);
+		}
 	}
 }

--- a/src/Test/System.Xaml/XamlXmlWriterTest.cs
+++ b/src/Test/System.Xaml/XamlXmlWriterTest.cs
@@ -1,4 +1,4 @@
-﻿//
+﻿﻿//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -1148,6 +1148,32 @@ namespace MonoTests.Portable.Xaml
 			Assert.AreEqual(ReadXml("NumericValues_NaN.xml").Trim(), XamlServices.Save(obj), "#1");
 		}
 
+		[Test]
+		public void Write_BaseClassPropertiesInSeparateNamespace()
+		{
+			var obj = new NamespaceTest2.TestClassWithDifferentBaseNamespace
+			{
+				TheName = "MyName",
+				SomeOtherProperty = "OtherValue",
+				Bar = "TheBar",
+				Baz = "TheBaz"
+			};
+			Assert.AreEqual(ReadXml("BaseClassPropertiesInSeparateNamespace.xml").Trim(), XamlServices.Save(obj), "#1");
+		}
+
+		[Test]
+		public void Write_BaseClassPropertiesInSeparateNamespace_WithChildren()
+		{
+			var obj = new NamespaceTest2.TestClassWithDifferentBaseNamespace
+			{
+				TheName = "MyName",
+				SomeOtherProperty = "OtherValue",
+				Bar = "TheBar",
+				Baz = "TheBaz",
+				Other = new TestClass5WithName { Bar = "TheBar2" }
+			};
+			Assert.AreEqual(ReadXml("BaseClassPropertiesInSeparateNamespace_WithChildren.xml").Trim(), XamlServices.Save(obj), "#1");
+		}
 	}
 
 	public class TestXmlWriterClass1

--- a/src/Test/XmlFiles/BaseClassPropertiesInSeparateNamespace.xml
+++ b/src/Test/XmlFiles/BaseClassPropertiesInSeparateNamespace.xml
@@ -1,0 +1,1 @@
+<TestClassWithDifferentBaseNamespace Bar="TheBar" SomeOtherProperty="OtherValue" TheName="MyName" xmlns="urn:mono-test2" />

--- a/src/Test/XmlFiles/BaseClassPropertiesInSeparateNamespace_WithChildren.xml
+++ b/src/Test/XmlFiles/BaseClassPropertiesInSeparateNamespace_WithChildren.xml
@@ -1,0 +1,5 @@
+<TestClassWithDifferentBaseNamespace Bar="TheBar" SomeOtherProperty="OtherValue" TheName="MyName" xmlns="urn:mono-test2" xmlns:mpx="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_5">
+  <TestClassWithDifferentBaseNamespace.Other>
+    <mpx:TestClass5WithName Bar="TheBar2" />
+  </TestClassWithDifferentBaseNamespace.Other>
+</TestClassWithDifferentBaseNamespace>

--- a/src/Test/XmlFiles/InvalidPropertiesShouldThrowException.xml
+++ b/src/Test/XmlFiles/InvalidPropertiesShouldThrowException.xml
@@ -1,0 +1,6 @@
+<TestClassWithDifferentBaseNamespace 
+	base:Bar="TheBar" 
+	SomeOtherProperty="OtherValue" 
+	base:TheName="MyName"
+	xmlns="urn:mono-test2" 
+	xmlns:base="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml-tests-net_4_5" />


### PR DESCRIPTION
- Read all unknown attributes in XamlXmlReader
- Throw exception if trying to write an unknown property in XamlObjectWriter
- Lazy load XamlType.PreferredXamlNamespace
- Use XamlType.PreferredXamlNamespace when writing members of an object instead of XamlMember.PreferredXamlNamespace as it might be different if the base class is in a different namespace
- Add tests for all this

Fixes #20