### PR TITLE
Trim Whitespace

### DIFF
--- a/src/Test/Portable.Xaml-tests-net_4_5.csproj
+++ b/src/Test/Portable.Xaml-tests-net_4_5.csproj
@@ -132,4 +132,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="XmlFiles\Whitespace.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -1601,6 +1601,23 @@ namespace MonoTests.Portable.Xaml
 			return !string.IsNullOrEmpty(Text) && Text != "bar";
 		}
 	}
+
+	[ContentProperty("Child")]
+	public class Whitespace
+	{
+		public string TabConvertedToSpaces { get; set; }
+		public string NewlineConvertedToSpaces { get; set; }
+		public string ConsecutiveSpaces { get; set; }
+		public string SpacesAroundTags { get; set; }
+		public string Preserve { get; set; }
+		public WhitespaceChild Child { get; set; }
+	}
+
+	[ContentProperty("Content")]
+	public class WhitespaceChild
+	{
+		public string Content { get; set; }
+	}
 }
 
 namespace XamlTest

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2105,5 +2105,20 @@ namespace MonoTests.Portable.Xaml
 			Assert.AreEqual("SomeValue", result.Property[0].Foo, "#2");
 
 		}
+
+		[Test]
+		public void Whitespace_ShouldBeCorrectlyHandled()
+		{
+			using (var xr = GetReader("Whitespace.xml"))
+			{
+				var des = (Whitespace)XamlServices.Load(xr);
+				Assert.AreEqual("hello world", des.TabConvertedToSpaces);
+				Assert.AreEqual("hello world", des.NewlineConvertedToSpaces);
+				Assert.AreEqual("hello world", des.ConsecutiveSpaces);
+				Assert.AreEqual("hello world", des.SpacesAroundTags);
+				Assert.AreEqual("  hello world\t", des.Preserve);
+				Assert.AreEqual("hello world", des.Child.Content);
+			}
+		}
 	}
 }

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2116,8 +2116,10 @@ namespace MonoTests.Portable.Xaml
 				Assert.AreEqual("hello world", des.NewlineConvertedToSpaces);
 				Assert.AreEqual("hello world", des.ConsecutiveSpaces);
 				Assert.AreEqual("hello world", des.SpacesAroundTags);
-				Assert.AreEqual("  hello world\t", des.Preserve);
 				Assert.AreEqual("hello world", des.Child.Content);
+
+				// TODO: xml:space="preserve" not yet implemented
+				// Assert.AreEqual("  hello world\t", des.Preserve);
 			}
 		}
 	}

--- a/src/Test/XmlFiles/Whitespace.xml
+++ b/src/Test/XmlFiles/Whitespace.xml
@@ -1,0 +1,13 @@
+<Whitespace xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Whitespace.TabConvertedToSpaces>hello	world</Whitespace.TabConvertedToSpaces>
+  <Whitespace.NewlineConvertedToSpaces>hello	
+  world</Whitespace.NewlineConvertedToSpaces>
+  <Whitespace.ConsecutiveSpaces>hello     	world</Whitespace.ConsecutiveSpaces>
+  <Whitespace.SpacesAroundTags>  
+    hello world  
+  </Whitespace.SpacesAroundTags>
+  <Whitespace.Preserve><x:String xml:space="preserve">  hello world	</x:String></Whitespace.Preserve>
+  <WhitespaceChild>
+    hello world
+  </WhitespaceChild>
+</Whitespace>


### PR DESCRIPTION
(Partially) fixes #76:

- Rules regarding east asian characters not implemented
- `xml:space="preserve"` is still not supported
- `XamlType.TrimSurroundingWhitespace` is not supported

This is my first time spelunking this code, so let me know if I've got stuff wrong.