### PR TITLE
Line info for errors

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 // Copyright (C) 2012 Xamarin Inc. http://xamarin.com
 //
@@ -103,9 +103,8 @@ namespace Portable.Xaml
 			}
 		}
 
-		//int line, column;
-		bool lineinfo_was_given;
-
+		int line, column;
+		
 		internal XamlObjectWriterSettings Settings {
 			get { return settings; }
 		}
@@ -123,14 +122,13 @@ namespace Portable.Xaml
 		}
 
 		public bool ShouldProvideLineInfo {
-			get { return lineinfo_was_given; }
+			get { return true; }
 		}
 
 		public void SetLineInfo (int lineNumber, int linePosition)
 		{
-//			line = lineNumber;
-//			column = linePosition;
-			lineinfo_was_given = true;
+			line = lineNumber;
+			column = linePosition;
 		}
 		
 		public void Clear ()
@@ -234,6 +232,13 @@ namespace Portable.Xaml
 				deferredWriter.DeferCount++;
 				return;
 			}
+
+			if (property.IsUnknown)
+				throw new XamlObjectWriterException($"Cannot set unknown member '{property}'")
+				      {
+					      LineNumber = line,
+						  LinePosition = column
+				      };
 
 			intl.WriteStartMember (property);
 

--- a/src/Portable.Xaml/Portable.Xaml/XamlServices.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlServices.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -123,7 +123,14 @@ namespace Portable.Xaml
 			if (xamlReader.NodeType == XamlNodeType.None)
 				xamlReader.Read ();
 
+			var xamlLineInfo = xamlReader as IXamlLineInfo;
+			var xamlLineConsumer = xamlWriter as IXamlLineInfoConsumer;
+			var shouldSetLineInfo = xamlLineInfo != null && xamlLineConsumer != null && xamlLineConsumer.ShouldProvideLineInfo && xamlLineInfo.HasLineInfo;
+
 			while (!xamlReader.IsEof) {
+				if (shouldSetLineInfo) {
+					xamlLineConsumer.SetLineInfo(xamlLineInfo.LineNumber, xamlLineInfo.LinePosition);
+				}
 				xamlWriter.WriteNode (xamlReader);
 				xamlReader.Read ();
 			}

--- a/src/Portable.Xaml/Portable.Xaml/XamlXmlWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlXmlWriter.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining

--- a/src/Test/Portable.Xaml-tests-net_4_5.csproj
+++ b/src/Test/Portable.Xaml-tests-net_4_5.csproj
@@ -65,6 +65,7 @@
     <Compile Include="System.Xaml\AttachablePropertyServicesTest.cs" />
     <Compile Include="System.Xaml\DummyValueSerializerContext.cs" />
     <Compile Include="System.Xaml\NamespaceDeclarationTest.cs" />
+    <Compile Include="System.Xaml\PropertyNotFoundTest.cs" />
     <Compile Include="System.Xaml\TestedTypes.cs" />
     <Compile Include="System.Xaml\ValueSerializerContextTest.cs" />
     <Compile Include="System.Xaml\XamlBackgroundReaderTest.cs" />
@@ -131,5 +132,10 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="XmlFiles\PropertyNotFound.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/Test/Portable.Xaml-tests-net_4_5.csproj
+++ b/src/Test/Portable.Xaml-tests-net_4_5.csproj
@@ -65,7 +65,6 @@
     <Compile Include="System.Xaml\AttachablePropertyServicesTest.cs" />
     <Compile Include="System.Xaml\DummyValueSerializerContext.cs" />
     <Compile Include="System.Xaml\NamespaceDeclarationTest.cs" />
-    <Compile Include="System.Xaml\PropertyNotFoundTest.cs" />
     <Compile Include="System.Xaml\TestedTypes.cs" />
     <Compile Include="System.Xaml\ValueSerializerContextTest.cs" />
     <Compile Include="System.Xaml\XamlBackgroundReaderTest.cs" />
@@ -87,6 +86,7 @@
     <Compile Include="System.Xaml\XamlReaderTestBase.cs" />
     <Compile Include="System.Xaml\XamlSchemaContextSettingsTest.cs" />
     <Compile Include="System.Xaml\XamlSchemaContextTest.cs" />
+    <Compile Include="System.Xaml\XamlServicesTest.cs" />
     <Compile Include="System.Xaml\XamlTypeTest.cs" />
     <Compile Include="System.Xaml\XamlXmlReaderSettingsTest.cs" />
     <Compile Include="System.Xaml\XamlXmlReaderTest.cs" />

--- a/src/Test/Portable.Xaml-tests-netstandard1.3.csproj
+++ b/src/Test/Portable.Xaml-tests-netstandard1.3.csproj
@@ -61,6 +61,7 @@
     <Compile Include="System.Xaml\AmbientPropertyValueTest.cs" />
     <Compile Include="System.Xaml\AttachableMemberIdentifierTest.cs" />
     <Compile Include="System.Xaml\AttachablePropertyServicesTest.cs" />
+    <Compile Include="System.Xaml\PropertyNotFoundTest.cs" />
     <Compile Include="System.Xaml\XamlObjectWriterCollectionTests.cs" />
     <Compile Include="System.Xaml\DummyValueSerializerContext.cs" />
     <Compile Include="System.Xaml\NamespaceDeclarationTest.cs" />
@@ -145,5 +146,10 @@
       <Project>{CDC8F791-56FC-4B15-AAD2-BC460657CC02}</Project>
       <Name>Portable.Xaml-netstandard1.3</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="XmlFiles\PropertyNotFound.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/Test/Portable.Xaml-tests-netstandard1.3.csproj
+++ b/src/Test/Portable.Xaml-tests-netstandard1.3.csproj
@@ -61,7 +61,6 @@
     <Compile Include="System.Xaml\AmbientPropertyValueTest.cs" />
     <Compile Include="System.Xaml\AttachableMemberIdentifierTest.cs" />
     <Compile Include="System.Xaml\AttachablePropertyServicesTest.cs" />
-    <Compile Include="System.Xaml\PropertyNotFoundTest.cs" />
     <Compile Include="System.Xaml\XamlObjectWriterCollectionTests.cs" />
     <Compile Include="System.Xaml\DummyValueSerializerContext.cs" />
     <Compile Include="System.Xaml\NamespaceDeclarationTest.cs" />
@@ -83,6 +82,7 @@
     <Compile Include="System.Xaml\XamlReaderTestBase.cs" />
     <Compile Include="System.Xaml\XamlSchemaContextSettingsTest.cs" />
     <Compile Include="System.Xaml\XamlSchemaContextTest.cs" />
+    <Compile Include="System.Xaml\XamlServicesTest.cs" />
     <Compile Include="System.Xaml\XamlTypeTest.cs" />
     <Compile Include="System.Xaml\XamlXmlReaderSettingsTest.cs" />
     <Compile Include="System.Xaml\XamlXmlReaderTest.cs" />

--- a/src/Test/Portable.Xaml-tests-pcl136.csproj
+++ b/src/Test/Portable.Xaml-tests-pcl136.csproj
@@ -65,7 +65,6 @@
     <Compile Include="System.Xaml\AttachablePropertyServicesTest.cs" />
     <Compile Include="System.Xaml\DummyValueSerializerContext.cs" />
     <Compile Include="System.Xaml\NamespaceDeclarationTest.cs" />
-    <Compile Include="System.Xaml\PropertyNotFoundTest.cs" />
     <Compile Include="System.Xaml\TestedTypes.cs" />
     <Compile Include="System.Xaml\ValueSerializerContextTest.cs" />
     <Compile Include="System.Xaml\XamlBackgroundReaderTest.cs" />
@@ -87,6 +86,7 @@
     <Compile Include="System.Xaml\XamlReaderTestBase.cs" />
     <Compile Include="System.Xaml\XamlSchemaContextSettingsTest.cs" />
     <Compile Include="System.Xaml\XamlSchemaContextTest.cs" />
+    <Compile Include="System.Xaml\XamlServicesTest.cs" />
     <Compile Include="System.Xaml\XamlTypeTest.cs" />
     <Compile Include="System.Xaml\XamlXmlReaderSettingsTest.cs" />
     <Compile Include="System.Xaml\XamlXmlReaderTest.cs" />

--- a/src/Test/Portable.Xaml-tests-pcl136.csproj
+++ b/src/Test/Portable.Xaml-tests-pcl136.csproj
@@ -65,6 +65,7 @@
     <Compile Include="System.Xaml\AttachablePropertyServicesTest.cs" />
     <Compile Include="System.Xaml\DummyValueSerializerContext.cs" />
     <Compile Include="System.Xaml\NamespaceDeclarationTest.cs" />
+    <Compile Include="System.Xaml\PropertyNotFoundTest.cs" />
     <Compile Include="System.Xaml\TestedTypes.cs" />
     <Compile Include="System.Xaml\ValueSerializerContextTest.cs" />
     <Compile Include="System.Xaml\XamlBackgroundReaderTest.cs" />
@@ -133,5 +134,10 @@
       <Project>{a283eef5-d2bf-47dd-afd6-a1db3df7cda0}</Project>
       <Name>Portable.Xaml-pcl136</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="XmlFiles\PropertyNotFound.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/Test/Portable.Xaml-tests-pcl259.csproj
+++ b/src/Test/Portable.Xaml-tests-pcl259.csproj
@@ -62,7 +62,6 @@
     <Compile Include="System.Xaml\AmbientPropertyValueTest.cs" />
     <Compile Include="System.Xaml\AttachableMemberIdentifierTest.cs" />
     <Compile Include="System.Xaml\AttachablePropertyServicesTest.cs" />
-    <Compile Include="System.Xaml\PropertyNotFoundTest.cs" />
     <Compile Include="System.Xaml\XamlObjectWriterCollectionTests.cs" />
     <Compile Include="System.Xaml\DummyValueSerializerContext.cs" />
     <Compile Include="System.Xaml\NamespaceDeclarationTest.cs" />
@@ -84,6 +83,7 @@
     <Compile Include="System.Xaml\XamlReaderTestBase.cs" />
     <Compile Include="System.Xaml\XamlSchemaContextSettingsTest.cs" />
     <Compile Include="System.Xaml\XamlSchemaContextTest.cs" />
+    <Compile Include="System.Xaml\XamlServicesTest.cs" />
     <Compile Include="System.Xaml\XamlTypeTest.cs" />
     <Compile Include="System.Xaml\XamlXmlReaderSettingsTest.cs" />
     <Compile Include="System.Xaml\XamlXmlReaderTest.cs" />

--- a/src/Test/Portable.Xaml-tests-pcl259.csproj
+++ b/src/Test/Portable.Xaml-tests-pcl259.csproj
@@ -62,6 +62,7 @@
     <Compile Include="System.Xaml\AmbientPropertyValueTest.cs" />
     <Compile Include="System.Xaml\AttachableMemberIdentifierTest.cs" />
     <Compile Include="System.Xaml\AttachablePropertyServicesTest.cs" />
+    <Compile Include="System.Xaml\PropertyNotFoundTest.cs" />
     <Compile Include="System.Xaml\XamlObjectWriterCollectionTests.cs" />
     <Compile Include="System.Xaml\DummyValueSerializerContext.cs" />
     <Compile Include="System.Xaml\NamespaceDeclarationTest.cs" />
@@ -136,5 +137,10 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="XmlFiles\PropertyNotFound.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/Test/Portable.Xaml-tests-uwp.csproj
+++ b/src/Test/Portable.Xaml-tests-uwp.csproj
@@ -120,6 +120,7 @@
     <Compile Include="System.Xaml\AttachablePropertyServicesTest.cs" />
     <Compile Include="System.Xaml\DummyValueSerializerContext.cs" />
     <Compile Include="System.Xaml\NamespaceDeclarationTest.cs" />
+    <Compile Include="System.Xaml\PropertyNotFoundTest.cs" />
     <Compile Include="System.Xaml\TestedTypes.cs" />
     <Compile Include="System.Xaml\ValueSerializerContextTest.cs" />
     <Compile Include="System.Xaml\XamlBackgroundReaderTest.cs" />
@@ -290,6 +291,7 @@
     <Content Include="XmlFiles\NumericValues_StandardTypes.xml" />
     <Content Include="XmlFiles\PositionalParametersWrapper.xml" />
     <Content Include="XmlFiles\PropertyDefinition.xml" />
+    <Content Include="XmlFiles\PropertyNotFound.xml" />
     <Content Include="XmlFiles\ReadOnlyPropertyContainer.xml" />
     <Content Include="XmlFiles\Reference.xml" />
     <Content Include="XmlFiles\StaticExtension.xml" />

--- a/src/Test/Portable.Xaml-tests-uwp.csproj
+++ b/src/Test/Portable.Xaml-tests-uwp.csproj
@@ -120,7 +120,6 @@
     <Compile Include="System.Xaml\AttachablePropertyServicesTest.cs" />
     <Compile Include="System.Xaml\DummyValueSerializerContext.cs" />
     <Compile Include="System.Xaml\NamespaceDeclarationTest.cs" />
-    <Compile Include="System.Xaml\PropertyNotFoundTest.cs" />
     <Compile Include="System.Xaml\TestedTypes.cs" />
     <Compile Include="System.Xaml\ValueSerializerContextTest.cs" />
     <Compile Include="System.Xaml\XamlBackgroundReaderTest.cs" />
@@ -142,6 +141,7 @@
     <Compile Include="System.Xaml\XamlReaderTestBase.cs" />
     <Compile Include="System.Xaml\XamlSchemaContextSettingsTest.cs" />
     <Compile Include="System.Xaml\XamlSchemaContextTest.cs" />
+    <Compile Include="System.Xaml\XamlServicesTest.cs" />
     <Compile Include="System.Xaml\XamlTypeTest.cs" />
     <Compile Include="System.Xaml\XamlXmlReaderSettingsTest.cs" />
     <Compile Include="System.Xaml\XamlXmlReaderTest.cs" />

--- a/src/Test/System.Xaml/PropertyNotFoundTest.cs
+++ b/src/Test/System.Xaml/PropertyNotFoundTest.cs
@@ -20,7 +20,7 @@ namespace MonoTests.Portable.Xaml
 		XamlReader GetReader(string filename)
 		{
 			string xml = File.ReadAllText(Compat.GetTestFile(filename)).UpdateXml();
-			return new XamlXmlReader(XmlReader.Create(new StringReader(xml)),new XamlXmlReaderSettings{ProvideLineInfo = true});
+			return new XamlXmlReader(XmlReader.Create(new StringReader(xml)), new XamlXmlReaderSettings{ProvideLineInfo = true});
 		}
 
 		[Test]
@@ -36,6 +36,26 @@ namespace MonoTests.Portable.Xaml
 			                                                  });
 			Assert.AreEqual(1, ex.LineNumber);
 			Assert.AreEqual(13, ex.LinePosition);
+		}
+
+		[Test]
+		public void CheckReaderPosition()
+		{
+			using(var reader = GetReader("PropertyNotFound.xml"))
+			{
+				var lineInfo = reader as IXamlLineInfo;
+				while (reader.Read())
+				{
+					if (reader.NodeType == XamlNodeType.StartMember)
+					{
+						if (reader.Member.Name == "Baz")
+						{
+							Assert.AreEqual(1, lineInfo.LineNumber);
+							Assert.AreEqual(13, lineInfo.LinePosition);
+						}
+					}
+				}
+			}
 		}
 	}
 }

--- a/src/Test/System.Xaml/PropertyNotFoundTest.cs
+++ b/src/Test/System.Xaml/PropertyNotFoundTest.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Xml;
+using NUnit.Framework;
+#if PCL
+using Portable.Xaml.Markup;
+using Portable.Xaml;
+using Portable.Xaml.Schema;
+#else
+using System.Windows.Markup;
+using System.Xaml;
+using System.Xaml.Schema;
+#endif
+
+namespace MonoTests.Portable.Xaml
+{
+	[TestFixture]
+	public class PropertyNotFoundTest
+	{
+		XamlReader GetReader(string filename)
+		{
+			string xml = File.ReadAllText(Compat.GetTestFile(filename)).UpdateXml();
+			return new XamlXmlReader(XmlReader.Create(new StringReader(xml)),new XamlXmlReaderSettings{ProvideLineInfo = true});
+		}
+
+		[Test]
+		public void DoTest()
+		{
+			var ex = Assert.Throws<XamlObjectWriterException>(() =>
+			                                                  {
+				                                                  using (var xr = GetReader("PropertyNotFound.xml"))
+				                                                  {
+					                                                  var des = (ComplexPositionalParameterWrapper)XamlServices.Load(xr);
+					                                                  Assert.Fail("Should not succeed!");
+				                                                  }
+			                                                  });
+			Assert.AreEqual(1, ex.LineNumber);
+			Assert.AreEqual(13, ex.LinePosition);
+		}
+	}
+}

--- a/src/Test/System.Xaml/XamlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlReaderTest.cs
@@ -102,5 +102,31 @@ namespace MonoTests.Portable.Xaml
 			Assert.IsFalse (sr.Read (), "#7");
 			Assert.AreEqual (XamlNodeType.None, xr.NodeType, "#7-2");
 		}
+
+		XamlReader GetReader(string filename)
+		{
+			string xml = File.ReadAllText(Compat.GetTestFile(filename)).UpdateXml();
+			return new XamlXmlReader(XmlReader.Create(new StringReader(xml)), new XamlXmlReaderSettings{ProvideLineInfo = true});
+		}
+
+		[Test]
+		public void CheckReaderPosition()
+		{
+			using(var reader = GetReader("PropertyNotFound.xml"))
+			{
+				var lineInfo = reader as IXamlLineInfo;
+				while (reader.Read())
+				{
+					if (reader.NodeType == XamlNodeType.StartMember)
+					{
+						if (reader.Member.Name == "Baz")
+						{
+							Assert.AreEqual(1, lineInfo.LineNumber, "Wrong LineNumber");
+							Assert.AreEqual(13, lineInfo.LinePosition, "Wrong LinePosition");
+						}
+					}
+				}
+			}
+		}
 	}
 }

--- a/src/Test/System.Xaml/XamlServicesTest.cs
+++ b/src/Test/System.Xaml/XamlServicesTest.cs
@@ -15,7 +15,7 @@ using System.Xaml.Schema;
 namespace MonoTests.Portable.Xaml
 {
 	[TestFixture]
-	public class PropertyNotFoundTest
+	public class XamlServicesTest
 	{
 		XamlReader GetReader(string filename)
 		{
@@ -24,7 +24,7 @@ namespace MonoTests.Portable.Xaml
 		}
 
 		[Test]
-		public void DoTest()
+		public void TestLineInfo()
 		{
 			var ex = Assert.Throws<XamlObjectWriterException>(() =>
 			                                                  {
@@ -34,28 +34,8 @@ namespace MonoTests.Portable.Xaml
 					                                                  Assert.Fail("Should not succeed!");
 				                                                  }
 			                                                  });
-			Assert.AreEqual(1, ex.LineNumber);
-			Assert.AreEqual(13, ex.LinePosition);
-		}
-
-		[Test]
-		public void CheckReaderPosition()
-		{
-			using(var reader = GetReader("PropertyNotFound.xml"))
-			{
-				var lineInfo = reader as IXamlLineInfo;
-				while (reader.Read())
-				{
-					if (reader.NodeType == XamlNodeType.StartMember)
-					{
-						if (reader.Member.Name == "Baz")
-						{
-							Assert.AreEqual(1, lineInfo.LineNumber);
-							Assert.AreEqual(13, lineInfo.LinePosition);
-						}
-					}
-				}
-			}
+			Assert.AreEqual(1, ex.LineNumber, "Wrong LineNumber");
+			Assert.AreEqual(13, ex.LinePosition, "Wrong LinePosition");
 		}
 	}
 }

--- a/src/Test/XmlFiles/PropertyNotFound.xml
+++ b/src/Test/XmlFiles/PropertyNotFound.xml
@@ -1,0 +1,2 @@
+<TestClass4 Baz="{x:Null}" xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />


### PR DESCRIPTION
Better approach to include line numbers in errors (I think).

Exposes an issue with XamlReader. Included a test case for it (but probably needs moving around).
