### PR TITLE
Fix attachable properties when using a namespace

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlXmlReader.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlXmlReader.cs
@@ -540,7 +540,7 @@ namespace Portable.Xaml
 							}
 							throw new NotSupportedException(String.Format("Attribute '{0}' is not supported", r.Name));
 						default:
-							if (string.IsNullOrEmpty(r.NamespaceURI))
+							if (string.IsNullOrEmpty(r.NamespaceURI) || r.LocalName.IndexOf('.') > 0)
 							{
 								atts.Add(new StringPair(r.Name, r.Value));
 								continue;

--- a/src/Test/Portable.Xaml-tests-core.csproj
+++ b/src/Test/Portable.Xaml-tests-core.csproj
@@ -25,9 +25,10 @@
 		<Compile Remove="UnitTestApp.*" />
 	</ItemGroup>
 	<ItemGroup>
-		<None Include="XmlFiles\*.*" CopyToOutputDirectory="PreserveNewest" />
+		<None Update="XmlFiles\*.*" CopyToOutputDirectory="PreserveNewest" />
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="NUnit" Version="3.9.0" />
+	  <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
 	</ItemGroup>
 </Project>

--- a/src/Test/Portable.Xaml-tests-net_4_5.csproj
+++ b/src/Test/Portable.Xaml-tests-net_4_5.csproj
@@ -1,107 +1,39 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{F4FA4B21-EF1C-48DE-8F4C-16496005FB94}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <NoWarn>1699</NoWarn>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <AssemblyName>Portable.Xaml_test_net_4_5</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net461</TargetFramework>
+		<RootNamespace>MonoTests.Portable.Xaml</RootNamespace>
+		<AssemblyName>Portable.Xaml_test_net_4_5</AssemblyName>
+		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE;NET_1_1;NET_2_0;NET_3_0;NET_3_5;NET_4_0;NET_4_5;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <OutputPath>..\..\artifacts\test\Debug\net461\</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <DefineConstants>NET_1_1;NET_2_0;NET_3_0;NET_3_5;NET_4_0;NET_4_5;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <OutputPath>..\..\artifacts\test\Release\net461\</OutputPath>
-    <DebugType>pdbonly</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-  <!-- Set AddAdditionalExplicitAssemblyReferences to false, otherwise if targetting .NET4.0, 
-  Microsoft.NETFramework.props will force a dependency on the assembly System.Core. This
-  is a problem to compile the Mono mscorlib.dll -->
-  <PropertyGroup>
-    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
-  </PropertyGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <Compile Include="Categories.cs" />
-    <Compile Include="System.Windows.Markup\ArrayExtensionTest.cs" />
-    <Compile Include="System.Windows.Markup\ReferenceTest.cs" />
-    <Compile Include="System.Windows.Markup\StaticExtensionTest.cs" />
-    <Compile Include="System.Windows.Markup\TypeExtensionConverterTest.cs" />
-    <Compile Include="System.Windows.Markup\TypeExtensionTest.cs" />
-    <Compile Include="System.Windows.Markup\ValueSerializerAttributeTest.cs" />
-    <Compile Include="System.Windows.Markup\ValueSerializerTest.cs" />
-    <Compile Include="System.Windows.Markup\XamlDeferLoadTest.cs" />
-    <Compile Include="System.Windows.Markup\XDataTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlMemberInvokerTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlTypeInvokerTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlTypeNameTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlTypeTypeConverterTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlValueConverterTest.cs" />
-    <Compile Include="System.Xaml\AmbientPropertyValueTest.cs" />
-    <Compile Include="System.Xaml\AttachableMemberIdentifierTest.cs" />
-    <Compile Include="System.Xaml\AttachablePropertyServicesTest.cs" />
-    <Compile Include="System.Xaml\DummyValueSerializerContext.cs" />
-    <Compile Include="System.Xaml\NamespaceDeclarationTest.cs" />
-    <Compile Include="System.Xaml\TestedTypes.cs" />
-    <Compile Include="System.Xaml\ValueSerializerContextTest.cs" />
-    <Compile Include="System.Xaml\XamlBackgroundReaderTest.cs" />
-    <Compile Include="System.Xaml\XamlDeferringLoaderTest.cs" />
-    <Compile Include="System.Xaml\XamlDirectiveTest.cs" />
-    <Compile Include="System.Xaml\XamlDuplicateMemberExceptionTest.cs" />
-    <Compile Include="System.Xaml\XamlLanguageTest.cs" />
-    <Compile Include="System.Xaml\XamlMemberTest.cs" />
-    <Compile Include="System.Xaml\XamlNodeListTest.cs" />
-    <Compile Include="System.Xaml\XamlNodeQueueTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectEventArgsTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectReaderSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectReaderTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectWriterCollectionTests.cs" />
-    <Compile Include="System.Xaml\XamlObjectWriterSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectWriterTest.cs" />
-    <Compile Include="System.Xaml\XamlReaderSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlReaderTest.cs" />
-    <Compile Include="System.Xaml\XamlReaderTestBase.cs" />
-    <Compile Include="System.Xaml\XamlSchemaContextSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlSchemaContextTest.cs" />
-    <Compile Include="System.Xaml\XamlTypeTest.cs" />
-    <Compile Include="System.Xaml\XamlXmlReaderSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlXmlReaderTest.cs" />
-    <Compile Include="System.Xaml\XamlXmlWriterSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlXmlWriterTest.cs" />
-    <Compile Include="Compat.cs" />
-  </ItemGroup>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+	  <OutputPath>..\..\artifacts\test\Debug</OutputPath>
+		<DefineConstants>TRACE;DEBUG;NET_4_5;HAS_TYPE_CONVERTER</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>
+		</DebugType>
+		<OutputPath>..\..\artifacts\test\Release</OutputPath>
+		<DefineConstants>TRACE;NET_4_5;HAS_TYPE_CONVERTER</DefineConstants>
+	</PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Xml" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xaml" />
   </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="MainTestPage.*" />
+		<Compile Remove="UnitTestApp.*" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="XmlFiles\*.*" CopyToOutputDirectory="PreserveNewest" />
+	</ItemGroup>
   <ItemGroup>
-    <None Include="XmlFiles\*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NUnit">
-      <Version>3.9.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Collections.Immutable">
-      <Version>1.4.0</Version>
-    </PackageReference>
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>
 </Project>

--- a/src/Test/Portable.Xaml-tests-netstandard1.3.csproj
+++ b/src/Test/Portable.Xaml-tests-netstandard1.3.csproj
@@ -1,112 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{E9DCCDCC-03A8-4BD1-888D-CEE86468A15A}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <NoWarn>1699</NoWarn>
-    <AssemblyName>Portable.Xaml_test_netstandard</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net461</TargetFramework>
+		<RootNamespace>MonoTests.Portable.Xaml</RootNamespace>
+		<AssemblyName>Portable.Xaml_test_netstandard</AssemblyName>
+		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE;NET_1_1;NET_2_0;NET_3_0;NET_3_5;NET_4_0;NET_4_5;PCL259;PCL;NETSTANDARD;HAS_TYPE_CONVERTER</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <OutputPath>..\..\artifacts\test\Debug\netstandard1.3\</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <DefineConstants>NET_1_1;NET_2_0;NET_3_0;NET_3_5;NET_4_0;NET_4_5;PCL259;PCL;NETSTANDARD;HAS_TYPE_CONVERTER</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <OutputPath>..\..\artifacts\test\Release\netstandard1.3\</OutputPath>
-    <DebugType>pdbonly</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-  <!-- Set AddAdditionalExplicitAssemblyReferences to false, otherwise if targetting .NET4.0, 
-  Microsoft.NETFramework.props will force a dependency on the assembly System.Core. This
-  is a problem to compile the Mono mscorlib.dll -->
-  <PropertyGroup>
-    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
-  </PropertyGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <Compile Include="Categories.cs" />
-    <Compile Include="System.Windows.Markup\ArrayExtensionTest.cs" />
-    <Compile Include="System.Windows.Markup\ReferenceTest.cs" />
-    <Compile Include="System.Windows.Markup\StaticExtensionTest.cs" />
-    <Compile Include="System.Windows.Markup\TypeExtensionConverterTest.cs" />
-    <Compile Include="System.Windows.Markup\TypeExtensionTest.cs" />
-    <Compile Include="System.Windows.Markup\ValueSerializerAttributeTest.cs" />
-    <Compile Include="System.Windows.Markup\ValueSerializerTest.cs" />
-    <Compile Include="System.Windows.Markup\XDataTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlMemberInvokerTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlTypeInvokerTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlTypeNameTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlTypeTypeConverterTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlValueConverterTest.cs" />
-    <Compile Include="System.Xaml\AmbientPropertyValueTest.cs" />
-    <Compile Include="System.Xaml\AttachableMemberIdentifierTest.cs" />
-    <Compile Include="System.Xaml\AttachablePropertyServicesTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectWriterCollectionTests.cs" />
-    <Compile Include="System.Xaml\DummyValueSerializerContext.cs" />
-    <Compile Include="System.Xaml\NamespaceDeclarationTest.cs" />
-    <Compile Include="System.Xaml\TestedTypes.cs" />
-    <Compile Include="System.Xaml\ValueSerializerContextTest.cs" />
-    <Compile Include="System.Xaml\XamlBackgroundReaderTest.cs" />
-    <Compile Include="System.Xaml\XamlDirectiveTest.cs" />
-    <Compile Include="System.Xaml\XamlDuplicateMemberExceptionTest.cs" />
-    <Compile Include="System.Xaml\XamlLanguageTest.cs" />
-    <Compile Include="System.Xaml\XamlMemberTest.cs" />
-    <Compile Include="System.Xaml\XamlNodeQueueTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectEventArgsTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectReaderSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectReaderTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectWriterSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectWriterTest.cs" />
-    <Compile Include="System.Xaml\XamlReaderSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlReaderTest.cs" />
-    <Compile Include="System.Xaml\XamlReaderTestBase.cs" />
-    <Compile Include="System.Xaml\XamlSchemaContextSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlSchemaContextTest.cs" />
-    <Compile Include="System.Xaml\XamlTypeTest.cs" />
-    <Compile Include="System.Xaml\XamlXmlReaderSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlXmlReaderTest.cs" />
-    <Compile Include="System.Xaml\XamlXmlWriterSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlXmlWriterTest.cs" />
-    <Compile Include="Compat.cs" />
-    <Compile Include="System.Xaml\XamlNodeListTest.cs" />
-    <Compile Include="System.Windows.Markup\XamlDeferLoadTest.cs" />
-    <Compile Include="System.Xaml\XamlDeferringLoaderTest.cs" />
-  </ItemGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+	  <OutputPath>..\..\artifacts\test\Debug\netstandard1.3</OutputPath>
+		<DefineConstants>TRACE;DEBUG;PCL259;PCL;NETSTANDARD;HAS_TYPE_CONVERTER</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>
+		</DebugType>
+		<OutputPath>..\..\artifacts\test\Release\netstandard1.3</OutputPath>
+		<DefineConstants>TRACE;PCL259;PCL;NETSTANDARD;HAS_TYPE_CONVERTER</DefineConstants>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Portable.Xaml\Portable.Xaml-netstandard1.3.csproj" />
+	</ItemGroup>
   <ItemGroup>
     <Reference Include="System.Xml" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="mscorlib" />
   </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="MainTestPage.*" />
+		<Compile Remove="UnitTestApp.*" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="XmlFiles\*.*" CopyToOutputDirectory="PreserveNewest" />
+	</ItemGroup>
   <ItemGroup>
-    <None Include="XmlFiles\*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Portable.Xaml\Portable.Xaml-netstandard1.3.csproj">
-      <Project>{CDC8F791-56FC-4B15-AAD2-BC460657CC02}</Project>
-      <Name>Portable.Xaml-netstandard1.3</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NUnit">
-      <Version>3.9.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Collections.Immutable">
-      <Version>1.4.0</Version>
-    </PackageReference>
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>
 </Project>

--- a/src/Test/Portable.Xaml-tests-pcl259.csproj
+++ b/src/Test/Portable.Xaml-tests-pcl259.csproj
@@ -1,105 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{FDA04C3E-7386-4F45-A7F2-C69DB33B72FF}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <NoWarn>1699</NoWarn>
-    <AssemblyName>Portable.Xaml_test_pcl259</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net461</TargetFramework>
+		<RootNamespace>MonoTests.Portable.Xaml</RootNamespace>
+		<AssemblyName>Portable.Xaml_test_pcl259</AssemblyName>
+		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE;NET_1_1;NET_2_0;NET_3_0;NET_3_5;NET_4_0;NET_4_5;PCL259;PCL</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <OutputPath>..\..\artifacts\test\Debug\portable-net45+win8+wpa81+wp8\</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <DefineConstants>NET_1_1;NET_2_0;NET_3_0;NET_3_5;NET_4_0;NET_4_5;PCL259;PCL</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <OutputPath>..\..\artifacts\test\Release\portable-net45+win8+wpa81+wp8\</OutputPath>
-    <DebugType>pdbonly</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <Compile Include="Categories.cs" />
-    <Compile Include="System.Windows.Markup\ArrayExtensionTest.cs" />
-    <Compile Include="System.Windows.Markup\ReferenceTest.cs" />
-    <Compile Include="System.Windows.Markup\StaticExtensionTest.cs" />
-    <Compile Include="System.Windows.Markup\TypeExtensionConverterTest.cs" />
-    <Compile Include="System.Windows.Markup\TypeExtensionTest.cs" />
-    <Compile Include="System.Windows.Markup\ValueSerializerAttributeTest.cs" />
-    <Compile Include="System.Windows.Markup\ValueSerializerTest.cs" />
-    <Compile Include="System.Windows.Markup\XDataTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlMemberInvokerTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlTypeInvokerTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlTypeNameTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlTypeTypeConverterTest.cs" />
-    <Compile Include="System.Xaml.Schema\XamlValueConverterTest.cs" />
-    <Compile Include="System.Xaml\AmbientPropertyValueTest.cs" />
-    <Compile Include="System.Xaml\AttachableMemberIdentifierTest.cs" />
-    <Compile Include="System.Xaml\AttachablePropertyServicesTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectWriterCollectionTests.cs" />
-    <Compile Include="System.Xaml\DummyValueSerializerContext.cs" />
-    <Compile Include="System.Xaml\NamespaceDeclarationTest.cs" />
-    <Compile Include="System.Xaml\TestedTypes.cs" />
-    <Compile Include="System.Xaml\ValueSerializerContextTest.cs" />
-    <Compile Include="System.Xaml\XamlBackgroundReaderTest.cs" />
-    <Compile Include="System.Xaml\XamlDirectiveTest.cs" />
-    <Compile Include="System.Xaml\XamlDuplicateMemberExceptionTest.cs" />
-    <Compile Include="System.Xaml\XamlLanguageTest.cs" />
-    <Compile Include="System.Xaml\XamlMemberTest.cs" />
-    <Compile Include="System.Xaml\XamlNodeQueueTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectEventArgsTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectReaderSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectReaderTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectWriterSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlObjectWriterTest.cs" />
-    <Compile Include="System.Xaml\XamlReaderSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlReaderTest.cs" />
-    <Compile Include="System.Xaml\XamlReaderTestBase.cs" />
-    <Compile Include="System.Xaml\XamlSchemaContextSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlSchemaContextTest.cs" />
-    <Compile Include="System.Xaml\XamlTypeTest.cs" />
-    <Compile Include="System.Xaml\XamlXmlReaderSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlXmlReaderTest.cs" />
-    <Compile Include="System.Xaml\XamlXmlWriterSettingsTest.cs" />
-    <Compile Include="System.Xaml\XamlXmlWriterTest.cs" />
-    <Compile Include="Compat.cs" />
-    <Compile Include="System.Xaml\XamlNodeListTest.cs" />
-    <Compile Include="System.Windows.Markup\XamlDeferLoadTest.cs" />
-    <Compile Include="System.Xaml\XamlDeferringLoaderTest.cs" />
-  </ItemGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+	  <OutputPath>..\..\artifacts\test\Debug\portable-net45+win8+wpa81+wp8</OutputPath>
+		<DefineConstants>TRACE;DEBUG;PCL259;PCL</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>
+		</DebugType>
+		<OutputPath>..\..\artifacts\test\Release\portable-net45+win8+wpa81+wp8</OutputPath>
+		<DefineConstants>TRACE;PCL259;PCL</DefineConstants>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Portable.Xaml\Portable.Xaml-pcl259.csproj" />
+	</ItemGroup>
   <ItemGroup>
     <Reference Include="System.Xml" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="MainTestPage.*" />
+		<Compile Remove="UnitTestApp.*" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="XmlFiles\*.*" CopyToOutputDirectory="PreserveNewest" />
+	</ItemGroup>
   <ItemGroup>
-    <None Include="XmlFiles\*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Portable.Xaml\Portable.Xaml-pcl259.csproj">
-      <Project>{179484EC-DB00-451A-AD2D-2E2AB20DE519}</Project>
-      <Name>Portable.Xaml-pcl259</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NUnit">
-      <Version>3.9.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Collections.Immutable">
-      <Version>1.4.0</Version>
-    </PackageReference>
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>
 </Project>

--- a/src/Test/Portable.Xaml-tests-uwp.csproj
+++ b/src/Test/Portable.Xaml-tests-uwp.csproj
@@ -320,7 +320,7 @@
       <Version>1.1.14</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
-      <Version>3.6.1</Version>
+      <Version>3.9.0</Version>
     </PackageReference>
     <PackageReference Include="nunit.xamarin">
       <Version>3.6.1</Version>

--- a/src/Test/System.Xaml/XamlReaderTestBase.cs
+++ b/src/Test/System.Xaml/XamlReaderTestBase.cs
@@ -3624,7 +3624,7 @@ if (i == 0) {
 			Assert.IsFalse (r.Read (), "end");
 		}
 		
-		protected void Read_AttachedProperty (XamlReader r)
+		protected void Read_AttachedProperty (XamlReader r, bool withNamespace = false)
 		{
 			var at = new XamlType (typeof (Attachable), r.SchemaContext);
 
@@ -3634,6 +3634,11 @@ if (i == 0) {
 			Assert.AreEqual ("", r.Namespace.Prefix, "ns#1-4");
 			var assns = "clr-namespace:MonoTests.Portable.Xaml;assembly=" + GetType ().GetTypeInfo().Assembly.GetName ().Name;
 			Assert.AreEqual (assns, r.Namespace.Namespace, "ns#1-5");
+
+			if (withNamespace)
+			{
+				this.ReadNamespace(r, "ns", assns, "ns#2");
+			}
 
 			// t:AttachedWrapper
 			Assert.IsTrue (r.Read (), "so#1-1");

--- a/src/Test/System.Xaml/XamlTypeTest.cs
+++ b/src/Test/System.Xaml/XamlTypeTest.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -932,7 +932,9 @@ namespace MonoTests.Portable.Xaml
 			Assert.IsNull(xt.ValueSerializer, "#3");
 #if HAS_TYPE_CONVERTER
 			Assert.IsNotInstanceOf<System.ComponentModel.DateTimeConverter>(xt.TypeConverter.ConverterInstance, "#4");
-			Assert.IsInstanceOf(Type.GetType("Portable.Xaml.ComponentModel.DateTimeConverter, Portable.Xaml"), xt.TypeConverter.ConverterInstance, "#4");
+#if PCL
+			Assert.IsInstanceOf(typeof(global::Portable.Xaml.XamlSchemaContext).Assembly.GetType("Portable.Xaml.ComponentModel.DateTimeConverter"), xt.TypeConverter.ConverterInstance, "#4");
+#endif
 #endif
 		}
 

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -682,6 +682,13 @@ namespace MonoTests.Portable.Xaml
 		}
 
 		[Test]
+		public void Read_AttachedPropertyWithNamespace()
+		{
+			var r = GetReader("AttachedPropertyWithNamespace.xml");
+			Read_AttachedProperty(r, true);
+		}
+
+		[Test]
 		public void Read_AbstractWrapper ()
 		{
 			var r = GetReader ("AbstractContainer.xml");

--- a/src/Test/XmlFiles/AttachedPropertyWithNamespace.xml
+++ b/src/Test/XmlFiles/AttachedPropertyWithNamespace.xml
@@ -1,0 +1,7 @@
+<AttachedWrapper ns:Attachable.Foo="x" 
+				 xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0"
+				 xmlns:ns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0">
+  <AttachedWrapper.Value>
+    <Attached ns:Attachable.Foo="y" />
+  </AttachedWrapper.Value>
+</AttachedWrapper>


### PR DESCRIPTION
- Allow attachable members when a namespace is specified
- Adds AttachedPropertyWithNamespace test

Fixes #75