### PR TITLE
Fixes setting an ICommand property to null on Windows

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/ValueSerializerContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ValueSerializerContext.cs
@@ -122,22 +122,21 @@ namespace Portable.Xaml
 
 			typeBuilder.AddInterfaceImplementation(typeDescriptorContextType);
 
-			Type notImplementedException = typeof(NotImplementedException);
-			var notImplementedExceptionConstructor = notImplementedException.GetTypeInfo().GetConstructors().First(r => r.GetParameters().Length == 0);
-
 			var getSetAttr = MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.Virtual;;
-			//public IContainer Container => throw new NotImplementedException();
+			//public IContainer Container => null;
 			var propertyBuilder = typeBuilder.DefineProperty("Container", PropertyAttributes.None, containerType, null);
 			var getter = typeBuilder.DefineMethod("get_Container", getSetAttr, containerType, null);
 			var il = getter.GetILGenerator();
-			il.ThrowException(notImplementedException);
+			il.Emit(OpCodes.Ldnull);
+			il.Emit(OpCodes.Ret);
 			propertyBuilder.SetGetMethod(getter);
 
-			//public PropertyDescriptor PropertyDescriptor => throw new NotImplementedException();
+			//public PropertyDescriptor PropertyDescriptor => null;
 			propertyBuilder = typeBuilder.DefineProperty("PropertyDescriptor", PropertyAttributes.None, propertyDescriptorType, null);
 			getter = typeBuilder.DefineMethod("get_PropertyDescriptor", getSetAttr, propertyDescriptorType, null);
 			il = getter.GetILGenerator();
-			il.ThrowException(notImplementedException);
+			il.Emit(OpCodes.Ldnull);
+			il.Emit(OpCodes.Ret);
 			propertyBuilder.SetGetMethod(getter);
 
 			s_valueSerializerType = typeBuilder.CreateType();
@@ -205,14 +204,12 @@ namespace Portable.Xaml
 
 		XamlSchemaContext IXamlSchemaContextProvider.SchemaContext => sctx;
 
-		public virtual object Instance => throw new NotImplementedException();
+		public virtual object Instance => null;
 
 #if HAS_TYPE_CONVERTER
-		public IContainer Container => throw new NotImplementedException();
+		public IContainer Container => null;
 
-		public PropertyDescriptor PropertyDescriptor => throw new NotImplementedException();
-#else
-		public PropertyInfo PropertyDescriptor => throw new NotImplementedException();
+		public PropertyDescriptor PropertyDescriptor => null;
 #endif
 
 		public virtual void OnComponentChanged()

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -32,6 +32,7 @@ using System.Reflection;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
+using System.Windows.Input;
 using NUnit.Framework;
 using sc = System.ComponentModel;
 #if !PCL136
@@ -111,6 +112,21 @@ namespace MonoTests.Portable.Xaml.NamespaceTest2
 
 namespace MonoTests.Portable.Xaml
 {
+	class MyCommand : ICommand
+	{
+		public event EventHandler CanExecuteChanged;
+
+		public bool CanExecute(object parameter) => true;
+
+		public void Execute(object parameter)
+		{
+		}
+	}
+
+	public static class StaticValues
+	{
+		public static ICommand Command => new MyCommand();
+	}
 
 	public class ArgumentAttributed
 	{
@@ -1614,6 +1630,12 @@ namespace MonoTests.Portable.Xaml
 	public class WhitespaceChild
 	{
 		public string Content { get; set; }
+	}
+
+	public class CommandContainer
+	{
+		public ICommand Command1 { get; set; }
+		public ICommand Command2 { get; set; }
 	}
 }
 

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2122,5 +2122,18 @@ namespace MonoTests.Portable.Xaml
 				// Assert.AreEqual("  hello world\t", des.Preserve);
 			}
 		}
+
+		[Test]
+		public void CommandContainer()
+		{
+			using (var xr = GetReader("CommandContainer.xml"))
+			{
+				var commandContainer = (CommandContainer)XamlServices.Load(xr);
+				Assert.IsNotNull(commandContainer);
+				Assert.IsNotNull(commandContainer.Command1);
+				Assert.IsInstanceOf<MyCommand>(commandContainer.Command1);
+				Assert.IsNull(commandContainer.Command2);
+			}
+		}
 	}
 }

--- a/src/Test/XmlFiles/CommandContainer.xml
+++ b/src/Test/XmlFiles/CommandContainer.xml
@@ -1,0 +1,5 @@
+<CommandContainer
+	Command1="{x:Static StaticValues.Command}"
+  Command2="{x:Null}"
+	xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+</CommandContainer>


### PR DESCRIPTION
On windows, it uses a presentation framework converter and gets ITypeDescriptorContext.Instance, which throws an exception in Portable.Xaml.  Now returning null until such time as its implemented.