### PR TITLE
Add functionality for pcl that doesn't expose type converters

### DIFF
--- a/src/Portable.Xaml/Helpers/ReflectionHelpers.cs
+++ b/src/Portable.Xaml/Helpers/ReflectionHelpers.cs
@@ -12,6 +12,8 @@ namespace Portable.Xaml
 		static Assembly componentModelAssembly = typeof(System.ComponentModel.CancelEventArgs).GetTypeInfo().Assembly;
 		static Assembly corlibAssembly = typeof(int).GetTypeInfo().Assembly;
 
+		public static readonly Type TypeConverterType = ReflectionHelpers.GetComponentModelType("System.ComponentModel.TypeConverter");
+
 		public static Type GetComponentModelType(string name) => componentModelAssembly.GetType(name);
 		public static Type GetCorlibType(string name) => corlibAssembly.GetType(name);
 	}

--- a/src/Portable.Xaml/Portable.Xaml.ComponentModel/ITypeConverter.cs
+++ b/src/Portable.Xaml/Portable.Xaml.ComponentModel/ITypeConverter.cs
@@ -1,8 +1,49 @@
 ﻿using System;
 using System.Globalization;
+using System.ComponentModel;
 
 namespace Portable.Xaml.ComponentModel
 {
+	[EnhancedXaml]
+	public interface IXamlTypeConverter
+	{
+		bool CanConvertFrom(object context, Type sourceType);
+		bool CanConvertTo(object context, Type destinationType);
+		object ConvertFrom(object context, CultureInfo culture, object value);
+		object ConvertTo(object context, CultureInfo culture, object value, Type destinationType);
+	}
+
+	class XamlTypeConverter : TypeConverter
+	{
+		IXamlTypeConverter _converter;
+
+		public XamlTypeConverter(IXamlTypeConverter converter)
+		{
+			_converter = converter ?? throw new ArgumentNullException(nameof(converter));
+		}
+
+		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+		{
+			return _converter.CanConvertFrom(context, sourceType);
+		}
+
+		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+		{
+			return _converter.CanConvertTo(context, destinationType);
+		}
+
+		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+		{
+			return _converter.ConvertFrom(context, culture, value);
+		}
+
+		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+		{
+			return _converter.ConvertTo(context, culture, value, destinationType);
+		}
+	}
+
+
 #if !HAS_TYPE_CONVERTER
 
 	interface ITypeDescriptorContext : IServiceProvider

--- a/src/Portable.Xaml/Portable.Xaml/XamlMember.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlMember.cs
@@ -505,6 +505,9 @@ namespace Portable.Xaml
 			if (t == typeof(object)) // it is different from XamlType.LookupTypeConverter().
 				return null;
 
+			var xamlTypeConverter = LookupXamlTypeConverter();
+			if (xamlTypeConverter != null)
+				return new XamlXamlTypeValueConverter(xamlTypeConverter, Type);
 
 			var converterName = CustomAttributeProvider.GetTypeConverterName(false);
 			if (converterName != null)
@@ -514,6 +517,9 @@ namespace Portable.Xaml
 
 			return Type.TypeConverter;
 		}
+
+		[EnhancedXaml]
+		protected virtual XamlValueConverter<IXamlTypeConverter> LookupXamlTypeConverter() => null;
 
 		protected virtual MethodInfo LookupUnderlyingGetter()
 		{

--- a/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
@@ -346,7 +346,7 @@ namespace Portable.Xaml
 #if !HAS_TYPE_CONVERTER
 			if (typeof(TConverterBase) == typeof(TypeConverter))
 			{
-				return new XamlTypeValueConverter<TConverterBase>(converterType, targetType);
+				return new XamlTypeValueConverter(converterType, targetType) as XamlValueConverter<TConverterBase>;
 			}
 #endif
 			return new XamlValueConverter<TConverterBase>(converterType, targetType);

--- a/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
@@ -333,7 +333,7 @@ namespace Portable.Xaml
 
 				if (types != null)
 				{
-					if (types.Any(xt => xt.UnderlyingType != null && xt.CanAssignFrom(state.Type)))
+					if (types.Any(xt => xt.UnderlyingType != null && state.Type.CanAssignTo(xt)))
 						yield return new AmbientPropertyValue(null, state.Value);
 				}
 				if (properties != null)
@@ -341,7 +341,7 @@ namespace Portable.Xaml
 					// get ambient properties in the stack
 					foreach (var prop in properties)
 					{
-						if (!prop.DeclaringType.CanAssignFrom(state.Type))
+						if (!state.Type.CanAssignTo(prop.DeclaringType))
 							continue;
 						var value = prop.Invoker.GetValue(state.Value);
 						yield return new AmbientPropertyValue(prop, value);


### PR DESCRIPTION
- XamlType.CanConvertTo/CanConvertFrom
- IXamlTypeConverter as a generic way to specify a type converter
- XamlType/XamlMember.LookupXamlTypeConverter() allow a generic type converter to be created without access to TypeConverter