### PR TITLE
Added netstandard2.0 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ test:
     only:
     - artifacts\test\Release\netstandard1.0\Portable.Xaml_test_netstandard10.dll
     - artifacts\test\Release\netstandard1.3\Portable.Xaml_test_netstandard13.dll
+    - artifacts\test\Release\netstandard1.3\Portable.Xaml_test_netstandard20.dll
     - artifacts\test\Release\net461\Portable.Xaml_test_net_4_5.dll
   categories:
     except:

--- a/src/Portable.Xaml.sln
+++ b/src/Portable.Xaml.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-netstandard2.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-tests-netstandard2.0", "Test\Portable.Xaml-tests-netstandard2.0.csproj", "{F85156F6-9EB3-4918-861C-4E1C64F1DF31}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-net451", "Portable.Xaml\Portable.Xaml-net451.csproj", "{6FA230D7-5141-45E9-AB65-76C37396537B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -207,6 +209,22 @@ Global
 		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Release|x64.Build.0 = Release|Any CPU
 		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Release|x86.ActiveCfg = Release|Any CPU
 		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Release|x86.Build.0 = Release|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Debug|ARM.Build.0 = Debug|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Debug|x64.Build.0 = Debug|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Debug|x86.Build.0 = Debug|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Release|ARM.ActiveCfg = Release|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Release|ARM.Build.0 = Release|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Release|x64.ActiveCfg = Release|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Release|x64.Build.0 = Release|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Release|x86.ActiveCfg = Release|Any CPU
+		{6FA230D7-5141-45E9-AB65-76C37396537B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Portable.Xaml.sln
+++ b/src/Portable.Xaml.sln
@@ -1,21 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+VisualStudioVersion = 15.0.27130.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Portable.Xaml-tests-net_4_5", "Test\Portable.Xaml-tests-net_4_5.csproj", "{F4FA4B21-EF1C-48DE-8F4C-16496005FB94}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-tests-net_4_5", "Test\Portable.Xaml-tests-net_4_5.csproj", "{F4FA4B21-EF1C-48DE-8F4C-16496005FB94}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Portable.Xaml.Benchmark", "Portable.Xaml.Benchmark\Portable.Xaml.Benchmark.csproj", "{AC406459-D324-4ADF-853D-A58B63396591}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Portable.Xaml-netstandard1.3", "Portable.Xaml\Portable.Xaml-netstandard1.3.csproj", "{CDC8F791-56FC-4B15-AAD2-BC460657CC02}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-netstandard1.3", "Portable.Xaml\Portable.Xaml-netstandard1.3.csproj", "{CDC8F791-56FC-4B15-AAD2-BC460657CC02}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Portable.Xaml-tests-netstandard1.0", "Test\Portable.Xaml-tests-netstandard1.0.csproj", "{FDA04C3E-7386-4F45-A7F2-C69DB33B72FF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-tests-netstandard1.0", "Test\Portable.Xaml-tests-netstandard1.0.csproj", "{FDA04C3E-7386-4F45-A7F2-C69DB33B72FF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Portable.Xaml-tests-netstandard1.3", "Test\Portable.Xaml-tests-netstandard1.3.csproj", "{E9DCCDCC-03A8-4BD1-888D-CEE86468A15A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-tests-netstandard1.3", "Test\Portable.Xaml-tests-netstandard1.3.csproj", "{E9DCCDCC-03A8-4BD1-888D-CEE86468A15A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Portable.Xaml-tests-uwp", "Test\Portable.Xaml-tests-uwp.csproj", "{1B4909D0-ECFB-4E32-8C02-B164DB1D64C6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Portable.Xaml-tests-core", "Test\Portable.Xaml-tests-core.csproj", "{1E5C8B3A-E196-499C-9849-9876EB621A7C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-tests-core", "Test\Portable.Xaml-tests-core.csproj", "{1E5C8B3A-E196-499C-9849-9876EB621A7C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{39859568-90DD-4BA1-A525-2899C232B44E}"
 	ProjectSection(SolutionItems) = preProject
@@ -25,7 +25,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{39859568
 		..\NuGet.Config = ..\NuGet.Config
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Portable.Xaml-netstandard1.0", "Portable.Xaml\Portable.Xaml-netstandard1.0.csproj", "{6A170ABB-8861-4010-A9F0-E49A9AFDD3A6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-netstandard1.0", "Portable.Xaml\Portable.Xaml-netstandard1.0.csproj", "{6A170ABB-8861-4010-A9F0-E49A9AFDD3A6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-netstandard2.0", "Portable.Xaml\Portable.Xaml-netstandard2.0.csproj", "{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-tests-netstandard2.0", "Test\Portable.Xaml-tests-netstandard2.0.csproj", "{F85156F6-9EB3-4918-861C-4E1C64F1DF31}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -171,9 +175,44 @@ Global
 		{6A170ABB-8861-4010-A9F0-E49A9AFDD3A6}.Release|x64.Build.0 = Release|Any CPU
 		{6A170ABB-8861-4010-A9F0-E49A9AFDD3A6}.Release|x86.ActiveCfg = Release|Any CPU
 		{6A170ABB-8861-4010-A9F0-E49A9AFDD3A6}.Release|x86.Build.0 = Release|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Debug|ARM.Build.0 = Debug|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Debug|x64.Build.0 = Debug|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Debug|x86.Build.0 = Debug|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Release|ARM.ActiveCfg = Release|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Release|ARM.Build.0 = Release|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Release|x64.ActiveCfg = Release|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Release|x64.Build.0 = Release|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Release|x86.ActiveCfg = Release|Any CPU
+		{FA7B4570-8FB9-4699-B24D-E27D7F4D8CCF}.Release|x86.Build.0 = Release|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Debug|ARM.Build.0 = Debug|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Debug|x64.Build.0 = Debug|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Debug|x86.Build.0 = Debug|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Release|ARM.Build.0 = Release|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Release|x64.ActiveCfg = Release|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Release|x64.Build.0 = Release|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Release|x86.ActiveCfg = Release|Any CPU
+		{F85156F6-9EB3-4918-861C-4E1C64F1DF31}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {436FBDA3-7DA0-43A9-9A8C-0E30EEF60B91}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/src/Portable.Xaml.sln
+++ b/src/Portable.Xaml.sln
@@ -31,7 +31,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-netstandard2.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-tests-netstandard2.0", "Test\Portable.Xaml-tests-netstandard2.0.csproj", "{F85156F6-9EB3-4918-861C-4E1C64F1DF31}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-net451", "Portable.Xaml\Portable.Xaml-net451.csproj", "{6FA230D7-5141-45E9-AB65-76C37396537B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Portable.Xaml-net45", "Portable.Xaml\Portable.Xaml-net45.csproj", "{6FA230D7-5141-45E9-AB65-76C37396537B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Portable.Xaml/Portable.Xaml-net45.csproj
+++ b/src/Portable.Xaml/Portable.Xaml-net45.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <RootNamespace>Portable.Xaml</RootNamespace>
     <AssemblyName>Portable.Xaml</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\..\artifacts\core\Debug\</OutputPath>
-    <DefineConstants>TRACE;PCL;NETSTANDARD;DEBUG;HAS_TYPE_CONVERTER;NETSTANDARD1_1;NETSTANDARD1_3;NET_451</DefineConstants>
+    <DefineConstants>TRACE;PCL;NETSTANDARD;DEBUG;HAS_TYPE_CONVERTER;NETSTANDARD1_1;NETSTANDARD1_3;NET_45</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <OutputPath>..\..\artifacts\core\Release\</OutputPath>
-    <DefineConstants>TRACE;PCL;NETSTANDARD;RELEASE;HAS_TYPE_CONVERTER;NETSTANDARD1_1;NETSTANDARD1_3;NET_451</DefineConstants>
+    <DefineConstants>TRACE;PCL;NETSTANDARD;RELEASE;HAS_TYPE_CONVERTER;NETSTANDARD1_1;NETSTANDARD1_3;NET_45</DefineConstants>
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
 </Project>

--- a/src/Portable.Xaml/Portable.Xaml-net451.csproj
+++ b/src/Portable.Xaml/Portable.Xaml-net451.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net451</TargetFramework>
+    <RootNamespace>Portable.Xaml</RootNamespace>
+    <AssemblyName>Portable.Xaml</AssemblyName>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OutputPath>..\..\artifacts\core\Debug\</OutputPath>
+    <DefineConstants>TRACE;PCL;NETSTANDARD;DEBUG;HAS_TYPE_CONVERTER;NETSTANDARD1_1;NETSTANDARD1_3;NET_451</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <OutputPath>..\..\artifacts\core\Release\</OutputPath>
+    <DefineConstants>TRACE;PCL;NETSTANDARD;RELEASE;HAS_TYPE_CONVERTER;NETSTANDARD1_1;NETSTANDARD1_3;NET_451</DefineConstants>
+    <DebugSymbols>True</DebugSymbols>
+  </PropertyGroup>
+</Project>

--- a/src/Portable.Xaml/Portable.Xaml-netstandard2.0.csproj
+++ b/src/Portable.Xaml/Portable.Xaml-netstandard2.0.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Portable.Xaml</RootNamespace>
+    <AssemblyName>Portable.Xaml</AssemblyName>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OutputPath>..\..\artifacts\core\Debug\</OutputPath>
+    <DefineConstants>TRACE;PCL;NETSTANDARD;DEBUG;HAS_TYPE_CONVERTER;NETSTANDARD1_1;NETSTANDARD1_3;NETSTANDARD2_0</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <OutputPath>..\..\artifacts\core\Release\</OutputPath>
+    <DefineConstants>TRACE;PCL;NETSTANDARD;RELEASE;HAS_TYPE_CONVERTER;NETSTANDARD1_1;NETSTANDARD1_3;NETSTANDARD2_0</DefineConstants>
+    <DebugSymbols>True</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/src/Portable.Xaml/Portable.Xaml.ComponentModel/ICustomAttributeProvider.cs
+++ b/src/Portable.Xaml/Portable.Xaml.ComponentModel/ICustomAttributeProvider.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using System.Linq;
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET_451
 [assembly:TypeForwardedTo(typeof(System.Reflection.ICustomAttributeProvider))]
 #else
 namespace System.Reflection

--- a/src/Portable.Xaml/Portable.Xaml.ComponentModel/ICustomAttributeProvider.cs
+++ b/src/Portable.Xaml/Portable.Xaml.ComponentModel/ICustomAttributeProvider.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using System.Linq;
 
-#if NETSTANDARD2_0 || NET_451
+#if NETSTANDARD2_0 || NET_45
 [assembly:TypeForwardedTo(typeof(System.Reflection.ICustomAttributeProvider))]
 #else
 namespace System.Reflection

--- a/src/Portable.Xaml/Portable.Xaml.ComponentModel/ICustomAttributeProvider.cs
+++ b/src/Portable.Xaml/Portable.Xaml.ComponentModel/ICustomAttributeProvider.cs
@@ -1,12 +1,28 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using System.Linq;
 
+#if NETSTANDARD2_0
+[assembly:TypeForwardedTo(typeof(System.Reflection.ICustomAttributeProvider))]
+#else
+namespace System.Reflection
+{
+	public interface ICustomAttributeProvider
+	{
+		object[] GetCustomAttributes(bool inherit);
+
+		object[] GetCustomAttributes(Type attributeType, bool inherit);
+
+		bool IsDefined(Type attributeType, bool inherit);
+	}
+}
+#endif
+
 namespace Portable.Xaml.ComponentModel
 {
-	class TypeAttributeProvider : ICustomAttributeProvider
+	class TypeAttributeProvider : System.Reflection.ICustomAttributeProvider
 	{
 		readonly Type type;
 
@@ -33,7 +49,7 @@ namespace Portable.Xaml.ComponentModel
 		}
 	}
 
-	class MemberAttributeProvider : ICustomAttributeProvider
+	class MemberAttributeProvider : System.Reflection.ICustomAttributeProvider
 	{
 		readonly MemberInfo info;
 
@@ -58,14 +74,5 @@ namespace Portable.Xaml.ComponentModel
 		{
 			return info.IsDefined(attributeType, inherit);
 		}
-	}
-
-	public interface ICustomAttributeProvider
-	{
-		object[] GetCustomAttributes(bool inherit);
-
-		object[] GetCustomAttributes(Type attributeType, bool inherit);
-
-		bool IsDefined(Type attributeType, bool inherit);
 	}
 }

--- a/src/Portable.Xaml/Portable.Xaml.Markup/ValueSerializer.cs
+++ b/src/Portable.Xaml/Portable.Xaml.Markup/ValueSerializer.cs
@@ -107,7 +107,7 @@ namespace Portable.Xaml.Markup
 			}
 
 			if (type == typeof(Uri))
-				return new TypeConverterValueSerializer(new UriTypeConverter());
+				return new TypeConverterValueSerializer(new Portable.Xaml.ComponentModel.UriTypeConverter());
 			return null;
 		}
 

--- a/src/Portable.Xaml/Portable.Xaml.nuspec
+++ b/src/Portable.Xaml/Portable.Xaml.nuspec
@@ -28,11 +28,23 @@ This allows you to read/write xaml for desktop, mobile, and .NET Core projects.
                 <dependency id="System.ComponentModel.TypeConverter" version="4.3.0" />
                 <dependency id="System.Runtime.Serialization.Primitives" version="4.3.0" />
             </group>
+            <group targetFramework=".NETStandard2.0">
+                <dependency id="NETStandard.Library" version="1.6.1" />
+                <dependency id="System.ComponentModel.TypeConverter" version="4.3.0" />
+                <dependency id="System.Runtime.Serialization.Primitives" version="4.3.0" />
+            </group>
+            <group targetFramework="net45">
+                <dependency id="NETStandard.Library" version="1.6.1" />
+                <dependency id="System.ComponentModel.TypeConverter" version="4.3.0" />
+                <dependency id="System.Runtime.Serialization.Primitives" version="4.3.0" />
+            </group>
         </dependencies>
 	</metadata>
 	<files>
 		<file src="..\..\artifacts\core\$configuration$\netstandard1.0\Portable.Xaml.dll" target="lib\netstandard1.0" />
 		<file src="..\..\artifacts\core\$configuration$\netstandard1.3\Portable.Xaml.dll" target="lib\netstandard1.3" />
+		<file src="..\..\artifacts\core\$configuration$\netstandard2.0\Portable.Xaml.dll" target="lib\netstandard2.0" />
+		<file src="..\..\artifacts\core\$configuration$\net45\Portable.Xaml.dll" target="lib\net45" />
 		<file src="..\..\LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -203,7 +203,7 @@ namespace Portable.Xaml
 				else
 				{
 #if NETSTANDARD1_3
-#if NET_451
+#if NET_45
 					var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
 #else
 					var baseDirectory = AppContext.BaseDirectory;

--- a/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
@@ -203,7 +203,13 @@ namespace Portable.Xaml
 				else
 				{
 #if NETSTANDARD1_3
-					foreach (var file in Directory.EnumerateFiles(AppContext.BaseDirectory, "*.dll"))
+#if NET_451
+					var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+#else
+					var baseDirectory = AppContext.BaseDirectory;
+#endif
+
+					foreach (var file in Directory.EnumerateFiles(baseDirectory, "*.dll"))
 					{
 						try
 						{

--- a/src/Portable.Xaml/Portable.Xaml/XamlType.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlType.cs
@@ -988,7 +988,7 @@ namespace Portable.Xaml
 				return SchemaContext.GetValueConverter<TypeConverter>(typeof(ComponentModel.PortableXamlDateTimeConverter), this);
 
 			if (t == typeof(Uri))
-				return SchemaContext.GetValueConverter<TypeConverter>(typeof(UriTypeConverter), this);
+				return SchemaContext.GetValueConverter<TypeConverter>(typeof(Portable.Xaml.ComponentModel.UriTypeConverter), this);
 
 			// It's still not decent to check CollectionConverter.
 

--- a/src/Test/Portable.Xaml-tests-core.csproj
+++ b/src/Test/Portable.Xaml-tests-core.csproj
@@ -18,7 +18,7 @@
 		<DefineConstants>TRACE;RELEASE;NETCOREAPP2_0;NETSTANDARD;PCL;CORE;</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\Portable.Xaml\Portable.Xaml-netstandard1.3.csproj" />
+		<ProjectReference Include="..\Portable.Xaml\Portable.Xaml-netstandard2.0.csproj" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Remove="MainTestPage.*" />

--- a/src/Test/Portable.Xaml-tests-netstandard2.0.csproj
+++ b/src/Test/Portable.Xaml-tests-netstandard2.0.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<TargetFramework>net461</TargetFramework>
+		<RootNamespace>MonoTests.Portable.Xaml</RootNamespace>
+		<AssemblyName>Portable.Xaml_test_netstandard13</AssemblyName>
+		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+	  <OutputPath>..\..\artifacts\test\Debug\netstandard2.0</OutputPath>
+		<DefineConstants>TRACE;DEBUG;PCL259;PCL;NETSTANDARD;NETSTANDARD1_3;HAS_TYPE_CONVERTER</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>
+		</DebugType>
+		<OutputPath>..\..\artifacts\test\Release\netstandard2.0</OutputPath>
+		<DefineConstants>TRACE;PCL259;PCL;NETSTANDARD;NETSTANDARD1_3;HAS_TYPE_CONVERTER</DefineConstants>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Portable.Xaml\Portable.Xaml-netstandard2.0.csproj" />
+	</ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Xml" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="MainTestPage.*" />
+		<Compile Remove="UnitTestApp.*" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Remove="MainTestPage.*" />
+		<None Remove="UnitTestApp.*" />
+		<None Remove="*.appxmanifest" />
+		<None Update="XmlFiles\*.*" CopyToOutputDirectory="PreserveNewest" />
+	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Also moved `ICustomAttributeProvider` to `System.Reflection` which breaks backward compatibility with previous versions. `netstandard1.3`/`netstandard1.1` and `netstandard2.0` versions are compatible along themselves due to the usage of [TypeForwardedTo](https://msdn.microsoft.com/en-us/library/system.runtime.compilerservices.typeforwardedtoattribute_members(VS.80).aspx) attribute. See [docs](https://docs.microsoft.com/en-us/dotnet/framework/app-domains/type-forwarding-in-the-common-language-runtime) for more details.