### PR TITLE
Support parent AmbientProvider in XamlObjectWriter

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/ValueSerializerContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ValueSerializerContext.cs
@@ -55,7 +55,7 @@ namespace Portable.Xaml
 		NamespaceResolver namespace_resolver;
 		PrefixLookup prefix_lookup;
 		XamlSchemaContext sctx;
-		IAmbientProvider ambient_provider;
+		Func<IAmbientProvider> _ambientProviderProvider;
 		IProvideValueTarget provideValue;
 		IRootObjectProvider rootProvider;
 		IDestinationTypeProvider destinationProvider;
@@ -144,7 +144,7 @@ namespace Portable.Xaml
 		}
 #endif
 
-		public static ValueSerializerContext Create(PrefixLookup prefixLookup, XamlSchemaContext schemaContext, IAmbientProvider ambientProvider, IProvideValueTarget provideValue, IRootObjectProvider rootProvider, IDestinationTypeProvider destinationProvider, IXamlObjectWriterFactory objectWriterFactory)
+		public static ValueSerializerContext Create(PrefixLookup prefixLookup, XamlSchemaContext schemaContext, Func<IAmbientProvider> ambientProvider, IProvideValueTarget provideValue, IRootObjectProvider rootProvider, IDestinationTypeProvider destinationProvider, IXamlObjectWriterFactory objectWriterFactory)
 		{
 #if !HAS_TYPE_CONVERTER
 			ValueSerializerContext context;
@@ -160,11 +160,11 @@ namespace Portable.Xaml
 			return context;
 		}
 
-		void Initialize(PrefixLookup prefixLookup, XamlSchemaContext schemaContext, IAmbientProvider ambientProvider, IProvideValueTarget provideValue, IRootObjectProvider rootProvider, IDestinationTypeProvider destinationProvider, IXamlObjectWriterFactory objectWriterFactory)
+		void Initialize(PrefixLookup prefixLookup, XamlSchemaContext schemaContext, Func<IAmbientProvider> ambientProvider, IProvideValueTarget provideValue, IRootObjectProvider rootProvider, IDestinationTypeProvider destinationProvider, IXamlObjectWriterFactory objectWriterFactory)
 		{
 			prefix_lookup = prefixLookup ?? throw new ArgumentNullException("prefixLookup");
 			sctx = schemaContext ?? throw new ArgumentNullException("schemaContext");
-			ambient_provider = ambientProvider;
+			_ambientProviderProvider = ambientProvider;
 			this.provideValue = provideValue;
 			this.rootProvider = rootProvider;
 			this.destinationProvider = destinationProvider;
@@ -188,7 +188,7 @@ namespace Portable.Xaml
 			if (serviceType == typeof(IXamlTypeResolver))
 				return TypeResolver;
 			if (serviceType == typeof(IAmbientProvider))
-				return ambient_provider;
+				return _ambientProviderProvider?.Invoke();
 			if (serviceType == typeof(IXamlSchemaContextProvider))
 				return this;
 			if (serviceType == typeof(IProvideValueTarget))

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -82,6 +82,7 @@ namespace Portable.Xaml
 		{
 		}
 
+		[EnhancedXaml]
 		public XamlObjectWriter(XamlSchemaContext schemaContext, XamlObjectWriterSettings settings, IAmbientProvider parentAmbientProvider)
 		{
 			if (schemaContext == null)

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 // Copyright (C) 2012 Xamarin Inc. http://xamarin.com
 //
@@ -78,13 +78,18 @@ namespace Portable.Xaml
 		}
 
 		public XamlObjectWriter(XamlSchemaContext schemaContext, XamlObjectWriterSettings settings)
+			: this(schemaContext, settings, null)
+		{
+		}
+
+		public XamlObjectWriter(XamlSchemaContext schemaContext, XamlObjectWriterSettings settings, IAmbientProvider parentAmbientProvider)
 		{
 			if (schemaContext == null)
 				throw new ArgumentNullException("schemaContext");
 			this.sctx = schemaContext;
 			this.settings = settings ?? new XamlObjectWriterSettings();
 			var manager = new XamlWriterStateManager<XamlObjectWriterException, XamlObjectWriterException>(false);
-			intl = new XamlObjectWriterInternal(this, sctx, manager);
+			intl = new XamlObjectWriterInternal(this, sctx, manager, parentAmbientProvider);
 		}
 
 		XamlSchemaContext sctx;
@@ -291,7 +296,13 @@ namespace Portable.Xaml
 		const string Xmlns2000Namespace = "http://www.w3.org/2000/xmlns/";
 
 		public XamlObjectWriterInternal(XamlObjectWriter source, XamlSchemaContext schemaContext, XamlWriterStateManager manager)
-			: base(schemaContext, manager)
+			: this(source, schemaContext, manager, null)
+		{
+		}
+		public XamlObjectWriterInternal(
+			XamlObjectWriter source, XamlSchemaContext schemaContext,
+			XamlWriterStateManager manager, IAmbientProvider parentAmbientProvider)
+			: base(schemaContext, manager, parentAmbientProvider)
 		{
 			this.source = source;
 			var ext = source.Settings.ExternalNameScope;

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -588,6 +588,81 @@ namespace MonoTests.Portable.Xaml
 		}
 	}
 
+	/// <summary>
+	/// Returns first ambient value matching provided key.
+	/// </summary>
+	public class AmbientValueExtension : MarkupExtension
+	{
+		public AmbientValueExtension()
+		{
+		}
+		public AmbientValueExtension(string resourceKey)
+		{
+			ResourceKey = resourceKey;
+		}
+
+		public string ResourceKey { get; set; }
+
+		public override object ProvideValue(IServiceProvider sp)
+		{
+			var schemaContext = (sp.GetService(typeof(IXamlSchemaContextProvider)) as IXamlSchemaContextProvider).SchemaContext;
+			var ambientProvider = (IAmbientProvider)sp.GetService(typeof(IAmbientProvider));
+			var resourceProviderType = schemaContext.GetXamlType(typeof(AmbientResourceProvider));
+			var ambientValues = ambientProvider.GetAllAmbientValues(resourceProviderType);
+			foreach (var resourceProvider in ambientValues.OfType<AmbientResourceProvider>())
+			{
+				if (resourceProvider.Resources.TryGetValue(ResourceKey, out var value))
+				{
+					return value;
+				}
+			}
+			throw new KeyNotFoundException("Resource not found");
+		}
+	}
+
+	/// <summary>
+	/// Simple implementation of <see cref="IAmbientProvider"/>'s single method
+	/// <see cref="IAmbientProvider.GetAllAmbientValues(XamlType[])"/> (others throw).
+	/// The method returns <see cref="Values"/>.
+	/// </summary>
+	public class SimpleAmbientProvider : IAmbientProvider
+	{
+		public IEnumerable<object> Values { get; set; }
+
+		public IEnumerable<object> GetAllAmbientValues(params XamlType[] types)
+		{
+			return Values;
+		}
+
+		public IEnumerable<AmbientPropertyValue> GetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, params XamlMember[] properties) => throw new NotImplementedException();
+
+		public IEnumerable<AmbientPropertyValue> GetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, bool searchLiveStackOnly, IEnumerable<XamlType> types, params XamlMember[] properties) => throw new NotImplementedException();
+
+		public object GetFirstAmbientValue(params XamlType[] types) => throw new NotImplementedException();
+
+		public AmbientPropertyValue GetFirstAmbientValue(IEnumerable<XamlType> ceilingTypes, params XamlMember[] properties) => throw new NotImplementedException();
+	}
+
+	/// <summary>
+	/// Ambient Resource dictionary container.
+	/// </summary>
+	[Ambient]
+	[ContentProperty(nameof(Content))]
+	public class AmbientResourceProvider
+	{
+		public Dictionary<string, object> Resources { get; } = new Dictionary<string, object>();
+
+		public object Content { get; set; }
+	}
+
+	/// <summary>
+	/// Wrapper of a single object-type property to allow ambient resource binding.
+	/// </summary>
+	public class AmbientResourceWrapper
+	{
+		public object Foo { get; set; }
+	}
+
 	public class PositionalParametersClass1 : MarkupExtension
 	{
 		public PositionalParametersClass1(string foo)

--- a/src/Test/XmlFiles/AmbientResourceProvider.xml
+++ b/src/Test/XmlFiles/AmbientResourceProvider.xml
@@ -1,0 +1,11 @@
+<AmbientResourceProvider xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib">
+  <AmbientResourceProvider.Resources>
+    <s:String x:Key="FooResourceKey">other resource content</s:String>
+  </AmbientResourceProvider.Resources>
+  <AmbientResourceProvider>
+    <AmbientResourceProvider.Resources>
+      <s:String x:Key="FooResourceKey">resource content</s:String>
+    </AmbientResourceProvider.Resources>
+    <AmbientResourceWrapper Foo="{AmbientValue FooResourceKey}"/>
+  </AmbientResourceProvider>
+</AmbientResourceProvider>

--- a/src/Test/XmlFiles/AmbientResourceWrapper.xml
+++ b/src/Test/XmlFiles/AmbientResourceWrapper.xml
@@ -1,0 +1,1 @@
+<AmbientResourceWrapper Foo="{AmbientValue FooResourceKey}" xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0" />


### PR DESCRIPTION
* This change introduces new public API in the form of new constructor for `XamlObjectWriter` that also takes `IAmbientProvider parentAmbientProvider`. This allows scenarios like searching in Ambient stack for StaticResource from within DataTemplate. DataTemplate's parsing is deferred and performed using another separate XamlObjectWriter to instantiate multiple instances from single XAML object.

* `ValueSerializerContext` now takes `Func<IAmbientProvider>` factory method instead of direct object reference, so that each request for the provider results in calling the factory. That enables the following feature:

* `XamlObjectWriterInternalBase` is no longer itself `IAmbientProvider`, instead the feature is extracted into `ObjectStatesAmbientProvider`, leaving method code all the same but encapsulating object state list, resulting in an immutable/stateless class that can be persisted in DataTemplate from the example use case.

* Also introduced is an internal `StackAmbientProvider` class that combines multiple providers and returns their results, essentially performing `SelectMany`.

* When passed, `parentAmbientProvider` is then joined with always-recreated `ObjectStatesAmbientProvider` into `StackAmbientProvider`, otherwise the behavior is unchanged.

Ported from https://github.com/AvaloniaUI/Portable.Xaml/pull/1