### PR TITLE
Fix attached member namespace resolution.

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlXmlReader.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlXmlReader.cs
@@ -571,7 +571,7 @@ namespace Portable.Xaml
 
 		XamlMember FindAttachableMember(string prefix, string typeName, string memberName)
 		{
-			string apns = prefix.Length > 0 ? r.LookupNamespace (prefix) : ResolveLocalNamespace(r.NamespaceURI);
+			string apns = r.LookupNamespace (prefix);
 			var axtn = new XamlTypeName (apns, typeName, null);
 			var at = sctx.GetXamlType (axtn);
 			return at?.GetAttachableMember (memberName);

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -108,6 +108,16 @@ namespace MonoTests.Portable.Xaml.NamespaceTest2
 	{
 		public string SomeOtherProperty { get; set; }
 	}
+
+	public class AttachedWrapperWithDifferentBaseNamespace : AttachedPropertyStore
+	{
+		public AttachedWrapperWithDifferentBaseNamespace()
+		{
+			Value = new Attached();
+		}
+
+		public Attached Value { get; set; }
+	}
 }
 
 namespace MonoTests.Portable.Xaml

--- a/src/Test/System.Xaml/XamlReaderTestBase.cs
+++ b/src/Test/System.Xaml/XamlReaderTestBase.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -3624,7 +3624,7 @@ if (i == 0) {
 			Assert.IsFalse (r.Read (), "end");
 		}
 		
-		protected void Read_AttachedProperty (XamlReader r, bool withNamespace = false)
+		protected void Read_AttachedProperty (XamlReader r, string additionalNamspace = null, Type wrapperType = null)
 		{
 			var at = new XamlType (typeof (Attachable), r.SchemaContext);
 
@@ -3632,18 +3632,16 @@ if (i == 0) {
 			Assert.AreEqual (XamlNodeType.NamespaceDeclaration, r.NodeType, "ns#1-2");
 			Assert.IsNotNull (r.Namespace, "ns#1-3");
 			Assert.AreEqual ("", r.Namespace.Prefix, "ns#1-4");
-			var assns = "clr-namespace:MonoTests.Portable.Xaml;assembly=" + GetType ().GetTypeInfo().Assembly.GetName ().Name;
-			Assert.AreEqual (assns, r.Namespace.Namespace, "ns#1-5");
 
-			if (withNamespace)
+			if (additionalNamspace != null)
 			{
-				this.ReadNamespace(r, "ns", assns, "ns#2");
+				this.ReadNamespace(r, "ns", additionalNamspace, "ns#2");
 			}
 
 			// t:AttachedWrapper
 			Assert.IsTrue (r.Read (), "so#1-1");
 			Assert.AreEqual (XamlNodeType.StartObject, r.NodeType, "so#1-2");
-			var xt = new XamlType (typeof (AttachedWrapper), r.SchemaContext);
+			var xt = new XamlType (wrapperType ?? typeof(AttachedWrapper), r.SchemaContext);
 			Assert.AreEqual (xt, r.Type, "so#1-3");
 
 			if (r is XamlXmlReader)

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -685,7 +685,16 @@ namespace MonoTests.Portable.Xaml
 		public void Read_AttachedPropertyWithNamespace()
 		{
 			var r = GetReader("AttachedPropertyWithNamespace.xml");
-			Read_AttachedProperty(r, true);
+			var ns = "clr-namespace:MonoTests.Portable.Xaml;assembly=" + GetType().GetTypeInfo().Assembly.GetName().Name;
+			Read_AttachedProperty(r, ns);
+		}
+
+		[Test]
+		public void Read_AttachedPropertyOnClassWithDifferentNamespace()
+		{
+			var r = GetReader("AttachedPropertyOnClassWithDifferentNamespace.xml");
+			var ns = "clr-namespace:MonoTests.Portable.Xaml.NamespaceTest2;assembly=" + GetType().GetTypeInfo().Assembly.GetName().Name;
+			Read_AttachedProperty(r, ns, typeof(NamespaceTest2.AttachedWrapperWithDifferentBaseNamespace));
 		}
 
 		[Test]

--- a/src/Test/XmlFiles/AttachedPropertyOnClassWithDifferentNamespace.xml
+++ b/src/Test/XmlFiles/AttachedPropertyOnClassWithDifferentNamespace.xml
@@ -1,0 +1,7 @@
+<ns:AttachedWrapperWithDifferentBaseNamespace xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0"
+                                        xmlns:ns="clr-namespace:MonoTests.Portable.Xaml.NamespaceTest2;assembly=Portable.Xaml_test_net_4_0"
+                                        Attachable.Foo="x" >
+  <ns:AttachedWrapperWithDifferentBaseNamespace.Value>
+    <Attached Attachable.Foo="y" />
+  </ns:AttachedWrapperWithDifferentBaseNamespace.Value>
+</ns:AttachedWrapperWithDifferentBaseNamespace>


### PR DESCRIPTION
When an attached property appears without a namespace, don't look up the type using the namespace for the current element: use the default namespace.

Added a test that was passing on System.Xaml and failing on Portable.Xaml. Not sure if the way I've done the test is the best, so feel free to change!

Fixes #95
