### PR TITLE
Added error for unknown object content members

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 // Copyright (C) 2012 Xamarin Inc. http://xamarin.com
 //
@@ -438,6 +438,8 @@ namespace Portable.Xaml
 			// FIXME: this condition needs to be examined. What is known to be prevented are: PositionalParameters, Initialization and Base (the last one sort of indicates there's a lot more).
 			else
 			{
+				if (property == XamlLanguage.UnknownContent)
+					throw new XamlObjectWriterException($"Type '{object_states.Peek().Type}' does not have a content property.");
 				if (property.IsUnknown)
 					throw new XamlObjectWriterException($"Cannot set unknown member '{property}'");
 				if (!property.IsDirective || ReferenceEquals(property, XamlLanguage.Name)) // x:Name requires an object instance

--- a/src/Portable.Xaml/Portable.Xaml/XamlXmlReader.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlXmlReader.cs
@@ -699,8 +699,19 @@ namespace Portable.Xaml
 					yield break;
 				}
 
-				// ok, then create unknown member.
-				xm = new XamlMember (name, xt, false); // FIXME: not sure if isAttachable is always false.
+				if (idx >= 0)
+				{
+					// Unknown property.
+					xm = new XamlMember(name, xt, false); // FIXME: not sure if isAttachable is always false.
+				}
+				else
+				{
+					// Unknown content member.
+					xm = XamlLanguage.UnknownContent;
+					foreach (var ni in ReadMember(xt, xm))
+						yield return ni;
+					yield break;
+				}
 			}
 
 			if (!r.IsEmptyElement) {
@@ -736,7 +747,7 @@ namespace Portable.Xaml
 				else
 					throw new XamlParseException (String.Format ("Read-only member '{0}' showed up in the source XML, and the xml contains element content that cannot be read.", xm.Name)) { LineNumber = this.LineNumber, LinePosition = this.LinePosition };
 			} else {
-				if (xm.Type.IsCollection || xm.Type.IsDictionary) {
+				if (xm.Type.IsCollection || xm.Type.IsDictionary || xm == XamlLanguage.UnknownContent) {
 					foreach (var ni in ReadCollectionItems (parentType, xm))
 						yield return ni;
 				}

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2135,5 +2135,15 @@ namespace MonoTests.Portable.Xaml
 				Assert.IsNull(commandContainer.Command2);
 			}
 		}
+
+		[Test]
+		public void Write_UnknownContent()
+		{
+			var xw = new XamlObjectWriter(sctx);
+			xw.WriteNamespace(new NamespaceDeclaration(XamlLanguage.Xaml2006Namespace, "x"));
+			xw.WriteStartObject(xt3);
+
+			Assert.Throws<XamlObjectWriterException>(() => xw.WriteStartMember(XamlLanguage.UnknownContent));
+		}
 	}
 }


### PR DESCRIPTION
This is to fix an error where such piece of code worked just fine:
```
XamlServices.Parse(@"<Int32 xmlns='http://schemas.microsoft.com/winfx/2006/xaml'><UnexpectedObject/></Int32>")
```
whereas it is expected to throw a `XamlObjectWriterException`, because `UnexpectedObject` is not a property or directive, and `Int32` is not a collection or dictionary, nor does it have a content property.

I discovered that the Microsoft's `XamlXmlReader` encloses such unexpected objects in the intrinsic  member `x:_UnknownContent`, so I did just that.

After the fix, the above statement throws the following exception (as expected):
> Portable.Xaml.XamlObjectWriterException: 'Type '{http://schemas.microsoft.com/winfx/2006/xaml}Int32' does not have a content property.'