### PR TITLE
WIP: Fix adding mixed text and elements to collections.

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
@@ -210,7 +210,7 @@ namespace Portable.Xaml
 			if (ReferenceEquals(xamlType, null))
 				throw new ArgumentNullException("xamlType");
 
-			manager.StartObject();
+			manager.StartObject(xamlType);
 			var cstate = new ObjectState() { Type = xamlType };
 			object_states.Push(cstate);
 

--- a/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
@@ -192,6 +192,7 @@ namespace Portable.Xaml
 			object_states.Push(state);
 
 			OnWriteGetObject();
+			manager.GotObject(object_states.Peek().Type);
 		}
 
 		public void WriteNamespace(NamespaceDeclaration namespaceDeclaration)

--- a/src/Portable.Xaml/Portable.Xaml/XamlXmlReader.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlXmlReader.cs
@@ -320,12 +320,22 @@ namespace Portable.Xaml
 			if (r.NodeType == XmlNodeType.EndElement)
 				yield break;
 
-			if (r.NodeType == XmlNodeType.Text || r.NodeType == XmlNodeType.CDATA) {
-				yield return Node (XamlNodeType.Value, NormalizeWhitespace(r.Value, true, true));
-				r.Read();
+			if (r.NodeType == XmlNodeType.Text || r.NodeType == XmlNodeType.CDATA)
+			{
+				if (currentMember == XamlLanguage.Items)
+				{
+					foreach (var x in ReadCollectionItems(parentType, currentMember))
+						yield return x;
+				}
+				else
+				{
+					yield return Node(XamlNodeType.Value, NormalizeWhitespace(r.Value, true, true));
+					r.Read();
+				}
+
 				yield break;
 			}
-			
+
 			if (r.NodeType != XmlNodeType.Element)
 			{
 				throw new XamlParseException (String.Format ("Element is expected, but got {0}", r.NodeType));
@@ -649,40 +659,28 @@ namespace Portable.Xaml
 
 		IEnumerable<XamlXmlNodeInfo> ReadMemberText (XamlType parentType, XamlType xt)
 		{
-			// this value is for Initialization, or Content property value
-			XamlMember xm;
-			if (xt.ContentProperty != null)
-				xm = xt.ContentProperty;
-			else if (xt.IsCollection)
-				xm = XamlLanguage.Items;
-			else
-				xm = XamlLanguage.Initialization;
-			yield return Node (XamlNodeType.StartMember, xm);
-
-			bool start = true;
-
-			while (r.NodeType != XmlNodeType.EndElement)
+			if (!xt.IsCollection)
 			{
-				switch (r.NodeType)
+				if (xt.ContentProperty == null)
 				{
-					case XmlNodeType.Text:
-						var text = r.Value;
-						r.Read();
-						yield return Node(XamlNodeType.Value, NormalizeWhitespace(text, start, r.NodeType == XmlNodeType.EndElement));
-						start = false;
-						break;
-					case XmlNodeType.Element:
-						foreach (var x in ReadObjectElement(parentType, xm))
-						{
-							yield return x;
-						}
-						break;
-					default:
-						throw new XamlParseException (String.Format ("Text or Element is expected, but got {0}", r.NodeType));
+					yield return Node(XamlNodeType.StartMember, XamlLanguage.Initialization);
+					yield return Node(XamlNodeType.Value, NormalizeWhitespace(r.Value, true, true));
+					r.Read();
+					yield return Node(XamlNodeType.EndMember, XamlLanguage.Initialization);
+				}
+				else
+				{
+					foreach (var x in ReadMember(parentType, xt.ContentProperty))
+						yield return x;
 				}
 			}
-
-			yield return Node(XamlNodeType.EndMember, xm);
+			else
+			{
+				yield return Node(XamlNodeType.StartMember, XamlLanguage.Items);
+				foreach (var x in ReadCollectionItems(parentType, XamlLanguage.Items))
+					yield return x;
+				yield return Node(XamlNodeType.EndMember, XamlLanguage.Items);
+			}
 		}
 
 		// member element, implicit member, children via content property, or value
@@ -773,8 +771,12 @@ namespace Portable.Xaml
 					throw new XamlParseException (String.Format ("Read-only member '{0}' showed up in the source XML, and the xml contains element content that cannot be read.", xm.Name)) { LineNumber = this.LineNumber, LinePosition = this.LinePosition };
 			} else {
 				if (xm.Type.IsCollection || xm.Type.IsDictionary || xm == XamlLanguage.UnknownContent) {
-					foreach (var ni in ReadCollectionItems (parentType, xm))
-						yield return ni;
+					foreach (var ni in ReadCollectionItems (parentType, xm)) {
+						if (ni.NodeType == XamlNodeType.None)
+							goto exit;
+						else
+							yield return ni;
+					}
 				}
 				else
 					foreach (var ni in ReadObjectElement (parentType, xm)) {
@@ -784,17 +786,37 @@ namespace Portable.Xaml
 					}
 			}
 
+exit:
 			yield return Node (XamlNodeType.EndMember, xm);
 		}
 
 		IEnumerable<XamlXmlNodeInfo> ReadCollectionItems (XamlType parentType, XamlMember xm)
 		{
-			for (r.MoveToContent (); r.NodeType != XmlNodeType.EndElement; r.MoveToContent ()) {
+			for (r.MoveToContent (); r.NodeType != XmlNodeType.EndElement; r.MoveToContent ())
+			{
+				bool start = true;
 
-				foreach (var ni in ReadObjectElement (parentType, xm)) {
-					if (ni.NodeType == XamlNodeType.None)
-						yield break;
-					yield return ni;
+				while (r.NodeType != XmlNodeType.EndElement)
+				{
+					switch (r.NodeType)
+					{
+						case XmlNodeType.Text:
+							var text = r.Value;
+							r.Read();
+							yield return Node(XamlNodeType.Value, NormalizeWhitespace(text, start, r.NodeType == XmlNodeType.EndElement));
+							start = false;
+							break;
+						case XmlNodeType.Element:
+							foreach (var x in ReadObjectElement(parentType, xm))
+							{
+								yield return x;
+							}
+							break;
+						case XmlNodeType.EndElement:
+							yield break;
+						default:
+							throw new XamlParseException(String.Format("Text or Element is expected, but got {0}", r.NodeType));
+					}
 				}
 			}
 		}

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -1402,11 +1402,14 @@ namespace MonoTests.Portable.Xaml
 			var text = item as string;
 			if (text != null)
 				Add(new CollectionItem { Name = text });
-			var other = item as OtherItem;
-			if (other != null)
-				Add(other.CollectionItem);
 			else
-				Add((CollectionItem)item);
+			{
+				var other = item as OtherItem;
+				if (other != null)
+					Add(other.CollectionItem);
+				else
+					Add((CollectionItem)item);
+			}
 			return Count - 1;
 		}
 	}

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -49,7 +49,7 @@ namespace MonoTests.Portable.Xaml
 	{
 		PropertyInfo str_len = typeof(string).GetProperty("Length");
 		XamlSchemaContext sctx = new XamlSchemaContext(null, null);
-		XamlType xt, xt3, xt4;
+		XamlType xt, xt3, xt4, xt5;
 		XamlMember xm2, xm3;
 
 		public XamlObjectWriterTest()
@@ -57,6 +57,7 @@ namespace MonoTests.Portable.Xaml
 			xt = new XamlType(typeof(string), sctx);
 			xt3 = new XamlType(typeof(TestClass1), sctx);
 			xt4 = new XamlType(typeof(Foo), sctx);
+			xt5 = new XamlType(typeof(List<TestClass1>), sctx);
 			xm2 = new XamlMember(typeof(TestClass1).GetProperty("TestProp1"), sctx);
 			xm3 = new XamlMember(typeof(TestClass1).GetProperty("TestProp2"), sctx);
 		}
@@ -511,6 +512,32 @@ namespace MonoTests.Portable.Xaml
 				xw.WriteStartObject(xt3); // Portable.Xaml throws here
 				xw.Close(); // .NET 4.5 throws here
 			});
+		}
+
+		[Test]
+		public void CollectionValueThenStartObject()
+		{
+			var xw = new XamlObjectWriter(sctx, null);
+			xw.WriteStartObject(xt5);
+			xw.WriteStartMember(XamlLanguage.Items);
+			xw.WriteValue(new TestClass1());
+			xw.WriteStartObject(xt3);
+			xw.Close();
+		}
+
+		[Test]
+		public void CollectionMixedObjectsAndValues()
+		{
+			var xw = new XamlObjectWriter(sctx, null);
+			xw.WriteStartObject(xt5);
+			xw.WriteStartMember(XamlLanguage.Items);
+			xw.WriteValue(new TestClass1());
+			xw.WriteStartObject(xt3);
+			xw.WriteEndObject();
+			xw.WriteValue(new TestClass1());
+			xw.WriteStartObject(xt3);
+			xw.WriteEndObject();
+			xw.Close();
 		}
 
 		[Test]

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -1268,6 +1268,76 @@ namespace MonoTests.Portable.Xaml
 		}
 
 		[Test]
+		public void Read_ContentCollectionShouldParseInnerTextAndItems()
+		{
+			var xaml = @"<CollectionParentItem xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'>
+	Hello
+    <CollectionItem Name='World'/>
+	!
+</CollectionParentItem>";
+			var r = GetReaderText(xaml);
+
+			r.Read(); // xmlns
+			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, r.NodeType);
+
+			r.Read(); // <CollectionParentItem>
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+
+			ReadBase(r);
+
+			r.Read(); // StartMember (Items)
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual(typeof(CollectionParentItem), r.Member.DeclaringType.UnderlyingType);
+			Assert.AreEqual(nameof(CollectionParentItem.Items), r.Member.Name);
+
+			r.Read(); // GetObject
+			Assert.AreEqual(XamlNodeType.GetObject, r.NodeType);
+
+			r.Read(); // StartMember (_Items)
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual(XamlLanguage.Items, r.Member);
+
+			r.Read(); // "Hello"
+			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
+			Assert.AreEqual("Hello ", r.Value);
+
+			r.Read(); // <CollectionItem>
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+
+			r.Read(); // StartMember (Name)
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual("Name", r.Member.Name);
+
+			r.Read(); // "World"
+			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
+			Assert.AreEqual("World", r.Value);
+
+			r.Read(); // EndMember (Name)
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+
+			r.Read(); // </CollectionItem>
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			r.Read(); // "!"
+			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
+			Assert.AreEqual(" !", r.Value);
+
+			r.Read(); // EndMember (_Items)
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+
+			r.Read(); // </CollectionItemCollectionAddOverride>
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			r.Read(); // EndMember (Items)
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+
+			r.Read(); // </CollectionParentItem>
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			Assert.IsFalse(r.Read()); // EOF
+		}
+
+		[Test]
 		public void Inner_Text_And_Items_Should_Be_Added_Via_IList()
 		{
 			var assembly = this.GetType().GetTypeInfo().Assembly.FullName;
@@ -1282,6 +1352,23 @@ namespace MonoTests.Portable.Xaml
 			Assert.AreEqual("Hello ", result[0].Name);
 			Assert.AreEqual("World", result[1].Name);
 			Assert.AreEqual(" !", result[2].Name);
+		}
+
+		[Test]
+		public void Inner_Text_And_Items_Should_Be_Added_To_Content_Property_Via_IList()
+		{
+			var assembly = this.GetType().GetTypeInfo().Assembly.FullName;
+			var xaml = $@"<CollectionParentItem xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly={assembly}'>
+	Hello
+    <CollectionItem Name='World'/>
+	!
+</CollectionParentItem>";
+			var result = (CollectionParentItem)XamlServices.Parse(xaml);
+
+			Assert.AreEqual(3, result.Items.Count);
+			Assert.AreEqual("Hello ", result.Items[0].Name);
+			Assert.AreEqual("World", result.Items[1].Name);
+			Assert.AreEqual(" !", result.Items[2].Name);
 		}
 	}
 }

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -1266,5 +1266,22 @@ namespace MonoTests.Portable.Xaml
 
 			Assert.IsFalse(r.Read()); // EOF
 		}
+
+		[Test]
+		public void Inner_Text_And_Items_Should_Be_Added_Via_IList()
+		{
+			var assembly = this.GetType().GetTypeInfo().Assembly.FullName;
+			var xaml = $@"<CollectionItemCollectionAddOverride xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly={assembly}'>
+	Hello
+    <CollectionItem Name='World'/>
+	!
+</CollectionItemCollectionAddOverride>";
+			var result = (CollectionItemCollectionAddOverride)XamlServices.Parse(xaml);
+
+			Assert.AreEqual(3, result.Count);
+			Assert.AreEqual("Hello ", result[0].Name);
+			Assert.AreEqual("World", result[1].Name);
+			Assert.AreEqual(" !", result[2].Name);
+		}
 	}
 }

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -1210,5 +1210,61 @@ namespace MonoTests.Portable.Xaml
 
 			Assert.IsFalse(reader.Read()); // EOF
 		}
+
+		[Test]
+		public void Read_CollectionShouldParseInnerTextAndItems()
+		{
+			var xaml = @"<CollectionItemCollectionAddOverride xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'>
+	Hello
+	<CollectionItem Name='World'/>
+	!
+</CollectionItemCollectionAddOverride>";
+			var r = GetReaderText(xaml);
+
+			r.Read(); // xmlns
+			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, r.NodeType);
+
+			r.Read(); // <CollectionItemCollectionAddOverride>
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+
+			ReadBase(r);
+
+			r.Read(); // StartMember (_Items)
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual(XamlLanguage.Items, r.Member);
+
+			r.Read(); // "Hello"
+			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
+			Assert.AreEqual("Hello ", r.Value);
+
+			r.Read(); // <CollectionItem>
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+
+			r.Read(); // StartMember (Name)
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual("Name", r.Member.Name);
+
+			r.Read(); // "World"
+			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
+			Assert.AreEqual("World", r.Value);
+
+			r.Read(); // EndMember (Name)
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+
+			r.Read(); // </CollectionItem>
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			r.Read(); // "!"
+			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
+			Assert.AreEqual(" !", r.Value);
+
+			r.Read(); // EndMember (_Items)
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+
+			r.Read(); // </CollectionItemCollectionAddOverride>
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			Assert.IsFalse(r.Read()); // EOF
+		}
 	}
 }


### PR DESCRIPTION
Syntax such as:

```xml
<TextBlock>
  This is an <Run>Example</Run>.
</TextBlock>
```

Is not working currently in Portable.Xaml. This PR is a WIP trying to get that supported.