### PR TITLE
Adding mixed text and elements to collections using IList.Add. 

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml.Schema/XamlTypeInvoker.cs
+++ b/src/Portable.Xaml/Portable.Xaml.Schema/XamlTypeInvoker.cs
@@ -105,7 +105,15 @@ namespace Portable.Xaml.Schema
 				}
 
 				addDelegate = CreateAddDelegate(instance, item, collectionType, itemType, key, mode);
-				addDelegate(instance, item);
+
+				try
+				{
+					addDelegate(instance, item);
+				}
+				catch (TargetInvocationException e)
+				{
+					throw e.InnerException;
+				}
 			}
 			else
 			{
@@ -160,21 +168,7 @@ namespace Portable.Xaml.Schema
 
 			if (mi == null)
 			{
-				var baseCollection = collectionType.GetTypeInfo().GetInterfaces()
-				                                   .FirstOrDefault(r => r.GetTypeInfo().IsGenericType
-				                                                   && r.GetTypeInfo().GetGenericTypeDefinition() == typeof(ICollection<>));
-				if (baseCollection != null)
-				{
-					mi = collectionType.GetRuntimeMethod("Add", baseCollection.GetTypeInfo().GetGenericArguments());
-					if (mi == null)
-						mi = LookupAddMethod(collectionType, baseCollection);
-				}
-				else
-				{
-					mi = collectionType.GetRuntimeMethod("Add", new Type[] { typeof(object) });
-					if (mi == null)
-						mi = LookupAddMethod(collectionType, typeof(IList));
-				}
+				mi = typeof(IList).GetTypeInfo().GetDeclaredMethod("Add");
 			}
 
 			return mi;

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -634,7 +634,7 @@ namespace Portable.Xaml
 				if (xt.IsDictionary)
 					mt.Invoker.AddToDictionary(parent, GetCorrectlyTypedValue(null, xt.KeyType, keyObj), GetCorrectlyTypedValue(null, xt.ItemType, obj));
 				else // collection. Note that state.Type isn't usable for PositionalParameters to identify collection kind.
-					mt.Invoker.AddToCollection(parent, GetCorrectlyTypedValue(null, xt.ItemType, obj));
+					mt.Invoker.AddToCollection(parent, GetCorrectlyTypedValue(null, xt.ItemType, obj, true));
 				return true;
 			}
 			else
@@ -647,7 +647,7 @@ namespace Portable.Xaml
 		// When it is passed null, then it returns a default instance.
 		// For example, passing null as Int32 results in 0.
 		// But do not immediately try to instantiate with the type, since the type might be abstract.
-		object GetCorrectlyTypedValue (XamlMember xm, XamlType xt, object value)
+		object GetCorrectlyTypedValue (XamlMember xm, XamlType xt, object value, bool fallbackToString = false)
 		{
 			try
 			{
@@ -694,7 +694,9 @@ namespace Portable.Xaml
 				throw new XamlObjectWriterException(String.Format("Could not convert object \'{0}' (of type {1}) to {2}: ", value, value != null ? (object)value.GetType() : "(null)", xt) + ex.Message, ex);
 			}
 
-			throw new XamlObjectWriterException (String.Format ("Value '{0}' (of type {1}) is not of or convertible to type {2} (member {3})", value, value != null ? (object) value.GetType () : "(null)", xt, xm));
+			return fallbackToString ?
+				value :
+				throw new XamlObjectWriterException(String.Format("Value '{0}' (of type {1}) is not of or convertible to type {2} (member {3})", value, value != null ? (object)value.GetType() : "(null)", xt, xm));
 		}
 
 		XamlType ResolveTypeFromName (string name)

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -1446,6 +1446,28 @@ namespace MonoTests.Portable.Xaml
 		public CollectionItemCollectionAddOverride Items { get; } = new CollectionItemCollectionAddOverride();
 	}
 
+	[ContentProperty("Items")]
+	public class AddIListParent
+	{
+		public AddIListCollection Items { get; set; } = new AddIListCollection();
+	}
+
+	public class AddIListCollection : Collection<AddIListItem>, IList
+	{
+		int IList.Add(object value)
+		{
+			// If the value is added as a string prepend a '@' to identify that case.
+			if (value is AddIListItem i) Add(i);
+			else Add(new AddIListItem { Name = '@' + value.ToString() });
+			return Count;
+		}
+	}
+
+	public class AddIListItem
+	{
+		public string Name { get; set; }
+	}
+
 	public class TestDeferredLoader : XamlDeferringLoader
 	{
 		public override object Load(XamlReader xamlReader, IServiceProvider serviceProvider)

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -1214,17 +1214,17 @@ namespace MonoTests.Portable.Xaml
 		[Test]
 		public void Read_CollectionShouldParseInnerTextAndItems()
 		{
-			var xaml = @"<CollectionItemCollectionAddOverride xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'>
+			var xaml = @"<AddIListCollection xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'>
 	Hello
-	<CollectionItem Name='World'/>
+	<AddIListItem Name='World'/>
 	!
-</CollectionItemCollectionAddOverride>";
+</AddIListCollection>";
 			var r = GetReaderText(xaml);
 
 			r.Read(); // xmlns
 			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, r.NodeType);
 
-			r.Read(); // <CollectionItemCollectionAddOverride>
+			r.Read(); // <AddIListCollection>
 			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
 
 			ReadBase(r);
@@ -1237,7 +1237,7 @@ namespace MonoTests.Portable.Xaml
 			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
 			Assert.AreEqual("Hello ", r.Value);
 
-			r.Read(); // <CollectionItem>
+			r.Read(); // <AddIListItem>
 			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
 
 			r.Read(); // StartMember (Name)
@@ -1251,7 +1251,7 @@ namespace MonoTests.Portable.Xaml
 			r.Read(); // EndMember (Name)
 			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
 
-			r.Read(); // </CollectionItem>
+			r.Read(); // </AddIListItem>
 			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
 
 			r.Read(); // "!"
@@ -1261,7 +1261,7 @@ namespace MonoTests.Portable.Xaml
 			r.Read(); // EndMember (_Items)
 			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
 
-			r.Read(); // </CollectionItemCollectionAddOverride>
+			r.Read(); // </AddIListCollection>
 			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
 
 			Assert.IsFalse(r.Read()); // EOF
@@ -1269,6 +1269,76 @@ namespace MonoTests.Portable.Xaml
 
 		[Test]
 		public void Read_ContentCollectionShouldParseInnerTextAndItems()
+		{
+			var xaml = @"<AddIListParent xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'>
+	Hello
+    <AddIListItem Name='World'/>
+	!
+</AddIListParent>";
+			var r = GetReaderText(xaml);
+
+			r.Read(); // xmlns
+			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, r.NodeType);
+
+			r.Read(); // <AddIListParent>
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+
+			ReadBase(r);
+
+			r.Read(); // StartMember (Items)
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual(typeof(AddIListParent), r.Member.DeclaringType.UnderlyingType);
+			Assert.AreEqual(nameof(AddIListParent.Items), r.Member.Name);
+
+			r.Read(); // GetObject
+			Assert.AreEqual(XamlNodeType.GetObject, r.NodeType);
+
+			r.Read(); // StartMember (_Items)
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual(XamlLanguage.Items, r.Member);
+
+			r.Read(); // "Hello"
+			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
+			Assert.AreEqual("Hello ", r.Value);
+
+			r.Read(); // <AddIListItem>
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+
+			r.Read(); // StartMember (Name)
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual("Name", r.Member.Name);
+
+			r.Read(); // "World"
+			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
+			Assert.AreEqual("World", r.Value);
+
+			r.Read(); // EndMember (Name)
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+
+			r.Read(); // </AddIListItem>
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			r.Read(); // "!"
+			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
+			Assert.AreEqual(" !", r.Value);
+
+			r.Read(); // EndMember (_Items)
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+
+			r.Read(); // </AddIListCollection>
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			r.Read(); // EndMember (Items)
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+
+			r.Read(); // </AddIListParent>
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			Assert.IsFalse(r.Read()); // EOF
+		}
+
+		[Test]
+		public void Read_ContentCollectionWithTypeConverterShouldParseInnerTextAndItems()
 		{
 			var xaml = @"<CollectionParentItem xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'>
 	Hello
@@ -1338,7 +1408,7 @@ namespace MonoTests.Portable.Xaml
 		}
 
 		[Test]
-		public void Inner_Text_And_Items_Should_Be_Added_Via_IList()
+		public void Inner_Text_And_Items_Should_Be_Added_Via_TypeConverter()
 		{
 			var assembly = this.GetType().GetTypeInfo().Assembly.FullName;
 			var xaml = $@"<CollectionItemCollectionAddOverride xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly={assembly}'>
@@ -1355,7 +1425,7 @@ namespace MonoTests.Portable.Xaml
 		}
 
 		[Test]
-		public void Inner_Text_And_Items_Should_Be_Added_To_Content_Property_Via_IList()
+		public void Inner_Text_And_Items_Should_Be_Added_To_Content_Property_Via_TypeConverter()
 		{
 			var assembly = this.GetType().GetTypeInfo().Assembly.FullName;
 			var xaml = $@"<CollectionParentItem xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly={assembly}'>
@@ -1369,6 +1439,39 @@ namespace MonoTests.Portable.Xaml
 			Assert.AreEqual("Hello ", result.Items[0].Name);
 			Assert.AreEqual("World", result.Items[1].Name);
 			Assert.AreEqual(" !", result.Items[2].Name);
+		}
+		[Test]
+		public void Inner_Text_And_Items_Should_Be_Added_Via_IList()
+		{
+			var assembly = this.GetType().GetTypeInfo().Assembly.FullName;
+			var xaml = $@"<AddIListCollection xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly={assembly}'>
+	Hello
+    <AddIListItem Name='World'/>
+	!
+</AddIListCollection>";
+			var result = (AddIListCollection)XamlServices.Parse(xaml);
+
+			Assert.AreEqual(3, result.Count);
+			Assert.AreEqual("@Hello ", result[0].Name);
+			Assert.AreEqual("@World", result[1].Name);
+			Assert.AreEqual("@ !", result[2].Name);
+		}
+
+		[Test]
+		public void Inner_Text_And_Items_Should_Be_Added_To_Content_Property_Via_IList()
+		{
+			var assembly = this.GetType().GetTypeInfo().Assembly.FullName;
+			var xaml = $@"<AddIListParent xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly={assembly}'>
+	Hello
+    <AddIListItem Name='World'/>
+	!
+</AddIListParent>";
+			var result = (AddIListParent)XamlServices.Parse(xaml);
+
+			Assert.AreEqual(3, result.Items.Count);
+			Assert.AreEqual("@Hello ", result.Items[0].Name);
+			Assert.AreEqual("@World", result.Items[1].Name);
+			Assert.AreEqual("@ !", result.Items[2].Name);
 		}
 	}
 }

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -1453,7 +1453,7 @@ namespace MonoTests.Portable.Xaml
 
 			Assert.AreEqual(3, result.Count);
 			Assert.AreEqual("@Hello ", result[0].Name);
-			Assert.AreEqual("@World", result[1].Name);
+			Assert.AreEqual("World", result[1].Name);
 			Assert.AreEqual("@ !", result[2].Name);
 		}
 
@@ -1470,7 +1470,7 @@ namespace MonoTests.Portable.Xaml
 
 			Assert.AreEqual(3, result.Items.Count);
 			Assert.AreEqual("@Hello ", result.Items[0].Name);
-			Assert.AreEqual("@World", result.Items[1].Name);
+			Assert.AreEqual("World", result.Items[1].Name);
 			Assert.AreEqual("@ !", result.Items[2].Name);
 		}
 	}


### PR DESCRIPTION
The previous PR #102 fixed adding mixed text and elements to collections if a `TypeConverter` was available for the type, however System.Xaml doesn't require this - it will try to add inline text in an element to a collection using `IList.Add`.

This PR implements that behavior, but it also changes the behavior of Portable.Xaml in that it no longer tries to add the item using a typed `IList<T>.Add` method and just goes straight for `IList.Add`. I'm not sure if that change in behavior is desired? Should we be trying the typed `Add` method first and falling back to `IList.Add`?

I also suspect some of the logic around adding to collections could be tidied up here, but I didn't want to make that change in this PR.