### PR TITLE
Add support for DictionaryKeyProperty in XamlObjectWriter

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -614,9 +614,11 @@ namespace Portable.Xaml
 				ms.Value = GetCorrectlyTypedValue (null, xm.Type, obj);
 			else if (ReferenceEquals(xm, XamlLanguage.Name) || xm == xt.GetAliasedProperty (XamlLanguage.Name))
 				ms.Value = GetCorrectlyTypedValue (xm, XamlLanguage.String, obj);
-			else if (ReferenceEquals(xm, XamlLanguage.Key))
-				state.KeyValue = GetCorrectlyTypedValue (null, xt.KeyType, obj);
-			else {
+			else if (ReferenceEquals(xm, XamlLanguage.Key) || xm == xt.GetAliasedProperty(XamlLanguage.Key)) {
+				var keyValue = GetCorrectlyTypedValue (null, xt.KeyType, obj);
+				state.KeyValue = keyValue;
+				ms.Value = keyValue;
+			} else {
 				if (!AddToCollectionIfAppropriate (xt, xm, parent, obj, keyObj)) {
 					if (!xm.IsReadOnly || xm.IsConstructorArgument)
 						ms.Value = GetCorrectlyTypedValue (xm, xm.Type, obj);

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -346,7 +346,6 @@ namespace Portable.Xaml
 			if (!state.Type.IsContentValue(service_provider))
 				InitializeObjectIfRequired(true);
 			state.IsXamlWriterCreated = true;
-			source.OnBeforeProperties(state.Value);
 		}
 
 		protected override void OnWriteGetObject()
@@ -563,6 +562,7 @@ namespace Portable.Xaml
 			state.Value = state.Type.Invoker.CreateInstance(argv);
 			state.IsInstantiated = true;
 			HandleBeginInit(state.Value);
+			source.OnBeforeProperties(state.Value);
 		}
 
 		protected override void OnWriteValue(object value)
@@ -755,6 +755,7 @@ namespace Portable.Xaml
 						state.Value = obj;
 						state.IsInstantiated = true;
 						HandleBeginInit(obj);
+						source.OnBeforeProperties(state.Value);
 
 						// set other writable properties now that the object is instantiated
 						foreach (var prop in state.WrittenProperties.Where(p => args.All(r => r.Member != p.Member)))
@@ -777,6 +778,7 @@ namespace Portable.Xaml
 			state.Value = obj;
 			state.IsInstantiated = true;
 			HandleBeginInit (obj);
+			source.OnBeforeProperties(state.Value);
 		}
 
 		internal IXamlNameResolver name_resolver {

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -1749,6 +1749,18 @@ namespace MonoTests.Portable.Xaml
 		public ICommand Command1 { get; set; }
 		public ICommand Command2 { get; set; }
 	}
+
+	[ContentProperty("Items")]
+	public class DictionaryContainer
+	{
+		public Dictionary<object, DictionaryItem> Items { get; } = new Dictionary<object, DictionaryItem>();
+	}
+
+	[DictionaryKeyProperty("Key")]
+	public class DictionaryItem
+	{
+		public object Key { get; set; }
+	}
 }
 
 namespace XamlTest

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2224,5 +2224,37 @@ namespace MonoTests.Portable.Xaml
 
 			Assert.Throws<XamlObjectWriterException>(() => xw.WriteStartMember(XamlLanguage.UnknownContent));
 		}
+
+		[Test]
+		public void Write_DictionaryKeyProperty()
+		{
+			var xw = new XamlObjectWriter(sctx);
+			var xDictionaryContainer = sctx.GetXamlType(typeof(DictionaryContainer));
+			var xDictionaryContainerItems = xDictionaryContainer.GetMember(nameof(DictionaryContainer.Items));
+			var xDictionaryItem = sctx.GetXamlType(typeof(DictionaryItem));
+			var xDictionaryItemKey = xDictionaryItem.GetMember(nameof(DictionaryItem.Key));
+			const string key = "Key";
+
+			xw.WriteNamespace(new NamespaceDeclaration(XamlLanguage.Xaml2006Namespace, "x"));
+			xw.WriteStartObject(xDictionaryContainer);
+			xw.WriteStartMember(xDictionaryContainerItems);
+			xw.WriteGetObject();
+			xw.WriteStartMember(XamlLanguage.Items);
+
+			xw.WriteStartObject(xDictionaryItem);
+			xw.WriteStartMember(xDictionaryItemKey);
+			xw.WriteValue(key);
+			xw.WriteEndMember();
+			xw.WriteEndObject();
+
+			xw.WriteEndMember();
+			xw.WriteEndObject();
+			xw.WriteEndMember();
+			xw.WriteEndObject();
+
+			var result = (DictionaryContainer)xw.Result;
+			Assert.IsTrue(result.Items.TryGetValue(key, out DictionaryItem item));
+			Assert.AreEqual(key, item.Key);
+		}
 	}
 }


### PR DESCRIPTION
It turned out that XamlObjectWriter did not support (i.e. completely ignored) the DictionaryKeyProperty attribute. Now it does.

Plus a small fix for NullReferenceException that was thrown by XamlObjectWriter when it was trying to call XamlObjectWriter.OnBeforeProperties before ObjectState.Value was even instantiated.