### PR TITLE
Added some failing tests for StringFormat strings.

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
@@ -65,8 +65,24 @@ namespace Portable.Xaml
 
 		public ParsedMarkupExtensionInfo(ParsedMarkupExtensionInfo info)
 		{
-			this.value = info.value;
-			this.index = info.index;
+			//before creating new ParsedMarkupExtensionInfo with another ParsedMarkupExtensionInfo
+			//we must calculate bounds of our new pmei. Scan rest of string and search first true-close bracket 
+			int nastedExtensionsCount = 0;
+
+			for (int i = info.index + 1; i < info.value.Length; i++)
+			{
+				if (info.value[i] == '{') nastedExtensionsCount++;
+				if (info.value[i] == '}')
+					if (nastedExtensionsCount > 0)
+						nastedExtensionsCount--;
+					else
+					{
+						this.value = info.value.Substring(info.index, i - info.index + 1);
+						break;
+					}
+			}
+
+			this.index = 0;
 			this.nsResolver = info.nsResolver;
 			this.sctx = info.sctx;
 		}
@@ -95,7 +111,7 @@ namespace Portable.Xaml
 
 		string ReadUntil (char[] ch, bool readToEnd = false, bool skip = true, char? escape = null)
 		{
-			var endidx = IndexOfAnyEscaped (new char[] { '}' }, value, escape, index);
+			var endidx = value.Length;
 			var idx = IndexOfAnyEscaped (ch, value, escape, index);
 			string val = null;
 			if (idx >= 0 && idx <= endidx)
@@ -234,6 +250,12 @@ namespace Portable.Xaml
 			switch (Current)
 			{
 			case '{':
+				// escaped sequence
+				if (value.Length - 1 > index && value[index + 1] == '}')
+				{
+					index += 2;
+					return ReadUntil(',', true, escape: '\\');
+				}
 				var markup = ReadMarkup();
 				if (markup != null)
 				{
@@ -319,8 +341,12 @@ namespace Portable.Xaml
 
 		public void Parse ()
 		{
-			if (!Read('{'))
-				throw Error ("Invalid markup extension attribute. It should begin with '{{', but was {0}", value);
+			//Get all inside brackets
+			if (value.Length > 1 && (value[0] != '{' || value[value.Length-1] != '}'))
+			{
+				throw new XamlParseException("Invalid markup extension attribute. It should begin with '{{' and end with '}}'");
+			}
+			value = value.Substring(1, value.Length - 2);
 			Name = ReadUntil (' ', true);
 			XamlTypeName xtn;
 			if (!XamlTypeName.TryParse (Name, nsResolver, out xtn))
@@ -328,8 +354,6 @@ namespace Portable.Xaml
 			Type = sctx.GetXamlType (xtn);
 
 			ParseArgument();
-			if (!Read('}'))
-				throw Error ("Expected '}}' in the markup extension attribute: '{0}'", value);
 		}
 
 		static Exception Error (string format, params object[] args)

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -522,7 +522,103 @@ namespace MonoTests.Portable.Xaml
 			Read_CustomExtensionWithCommasInPositionalValue(r);
 		}
 
-        [Test]
+		[Test]
+		public void Read_CustomExtensionWithStringFormat()
+		{
+			var r = GetReaderText(@"<ValueWrapper 
+	StringValue='{MyExtension2 Bar=Hello {0}}' 
+	xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+	xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'/>");
+
+			r.Read(); // ns
+			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, r.NodeType);
+			r.Read(); // ns
+			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, r.NodeType);
+			r.Read();
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+			var xt = r.Type;
+			Assert.AreEqual(r.SchemaContext.GetXamlType(typeof(ValueWrapper)), xt);
+
+			if (r is XamlXmlReader)
+				ReadBase(r);
+
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual(xt.GetMember("StringValue"), r.Member);
+			Assert.IsTrue(r.Read(), "#5");
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+			Assert.AreEqual(r.SchemaContext.GetXamlType(typeof(MyExtension2)), xt = r.Type);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual(xt.GetMember("Bar"), r.Member);
+
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
+			Assert.AreEqual("Hello {0}", r.Value);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			Assert.IsFalse(r.Read());
+			Assert.AreEqual(XamlNodeType.None, r.NodeType);
+			Assert.IsTrue(r.IsEof);
+		}
+
+		[Test]
+		public void Read_CustomExtensionWithStringFormatEscape()
+		{
+			var r = GetReaderText(@"<ValueWrapper 
+	StringValue='{MyExtension2 Bar={}{0} Hello}' 
+	xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+	xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'/>");
+
+			r.Read(); // ns
+			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, r.NodeType);
+			r.Read(); // ns
+			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, r.NodeType);
+			r.Read();
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+			var xt = r.Type;
+			Assert.AreEqual(r.SchemaContext.GetXamlType(typeof(ValueWrapper)), xt);
+
+			if (r is XamlXmlReader)
+				ReadBase(r);
+
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual(xt.GetMember("StringValue"), r.Member);
+			Assert.IsTrue(r.Read(), "#5");
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+			Assert.AreEqual(r.SchemaContext.GetXamlType(typeof(MyExtension2)), xt = r.Type);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual(xt.GetMember("Bar"), r.Member);
+
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
+			Assert.AreEqual("{0} Hello", r.Value);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			Assert.IsFalse(r.Read());
+			Assert.AreEqual(XamlNodeType.None, r.NodeType);
+			Assert.IsTrue(r.IsEof);
+		}
+
+		[Test]
         public void Load_CustomExtensionWithEscapeChars()
         {
             var r = GetReader("CustomExtensionWithEscapeChars.xml");


### PR DESCRIPTION
Portable.Xaml does not handle "string format" strings in markup extensions correctly. These are strings such as:

`{Binding StringFormat=Hello {0}}`
`{Binding StringFormat={}{0} Hello}`

This PR so far adds a couple of failing tests for these cases, but I'm not sure yet how to fix them as I don't quite understand 1. what the rules are and 2. how `ParsedMarkupExtenionInfo` works.

If anyone would like to chip in here, feel free! ;)