### PR TITLE
Correct handle ISupportInitialize.BeginInit class with predifined RootObject

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -339,6 +339,7 @@ namespace Portable.Xaml
 						throw new XamlObjectWriterException(String.Format("RootObjectInstance type '{0}' is not assignable to '{1}'", obj.GetType(), state.Type));
 					state.Value = obj;
 					state.IsInstantiated = true;
+					source.OnBeforeProperties(state.Value);
 				}
 				root_state = state;
 			}

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -339,6 +339,7 @@ namespace Portable.Xaml
 						throw new XamlObjectWriterException(String.Format("RootObjectInstance type '{0}' is not assignable to '{1}'", obj.GetType(), state.Type));
 					state.Value = obj;
 					state.IsInstantiated = true;
+					HandleBeginInit(obj);
 					source.OnBeforeProperties(state.Value);
 				}
 				root_state = state;

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -379,6 +379,21 @@ namespace MonoTests.Portable.Xaml
 		public DateTime TheDateAndTime { get; set; }
 	}
 
+	public class TestClass7 : ISupportInitialize
+	{
+		public int State { get; set; }
+
+		public void BeginInit()
+		{
+			State++;
+		}
+
+		public void EndInit()
+		{
+			State--;
+		}
+	}
+
 	[RuntimeNameProperty("TheName")]
 	public class TestClass5WithName : TestClass5
 	{

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2256,5 +2256,32 @@ namespace MonoTests.Portable.Xaml
 			Assert.IsTrue(result.Items.TryGetValue(key, out DictionaryItem item));
 			Assert.AreEqual(key, item.Key);
 		}
+
+		[Test]
+		public void TestISupportInitializeBeginInitEqualsEndInit()
+		{
+			var xml =
+$@"<TestClass7 
+		xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0' 
+		xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml' />".UpdateXml();
+			
+			XamlSchemaContext context = new XamlSchemaContext();
+
+			TextReader tr = new StringReader(xml);
+
+			XamlObjectWriterSettings xows = new XamlObjectWriterSettings()
+			{
+				RootObjectInstance = new TestClass7()
+			};
+
+			XamlObjectWriter ow = new XamlObjectWriter(context, xows);
+			XamlXmlReader r = new XamlXmlReader(tr);
+
+			XamlServices.Transform(r, ow);
+
+			var testClass = (TestClass7)ow.Result;
+
+			Assert.AreEqual(0, testClass.State);
+		}
 	}
 }


### PR DESCRIPTION
Hi! I found the different  behavour in Portable.Xaml and System.Xaml when you set RootObject via XamlObjectWriterSettings. 

Current behavour:
The ```BeginInit``` method not fired, but ```EndInit``` fired always.

System.Xaml:
The fired times ```BeginInit``` and ```EndInit``` are equals.

After fix:
The fired times ```BeginInit``` and ```EndInit``` are equals.