### PR TITLE
Fix for XmlNsDefinition in referenced assemblies

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
@@ -141,6 +141,9 @@ namespace Portable.Xaml
 
 		static IEnumerable<Assembly> GetAppDomainAssemblies()
 		{
+#if NETSTANDARD2_0
+			return AppDomain.CurrentDomain.GetAssemblies();
+#else
 			try
 			{
 				var appDomainType = Type.GetType("System.AppDomain", false);
@@ -163,6 +166,7 @@ namespace Portable.Xaml
 			{
 				return null;
 			}
+#endif
 		}
 
 #if !PCL136


### PR DESCRIPTION
Fixes #105 

This seems to fix the issue in my testing. Weirdly, you would think this code does the same thing. Using reflection in this way is pretty fragile anyway. 