### PR TITLE
Remove internal from XamlSchemaContext.GetXamlType.

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
@@ -423,7 +423,7 @@ namespace Portable.Xaml
 			return GetXamlType(n.Namespace, n.Name, typeArgs);
 		}
 
-		protected internal virtual XamlType GetXamlType(string xamlNamespace, string name, params XamlType[] typeArguments)
+		protected virtual XamlType GetXamlType(string xamlNamespace, string name, params XamlType[] typeArguments)
 		{
 			XamlType ret;
 			var key = Tuple.Create(xamlNamespace, name);


### PR DESCRIPTION
In System.Xaml this method is simply `protected`: having the `internal` modifier on the method means that the API is not compatible with System.Xaml because the compiler complains:

```
cannot change access modifiers when overriding 'protected internal' inherited member 'XamlSchemaContext.GetXamlType(string, string, params XamlType[])'
```