### PR TITLE
 Pass null typeArguments to GetXamlType.

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
@@ -423,7 +423,7 @@ namespace Portable.Xaml
 			return GetXamlType(n.Namespace, n.Name, typeArgs);
 		}
 
-		protected internal virtual XamlType GetXamlType(string xamlNamespace, string name, params XamlType[] typeArguments)
+		protected virtual XamlType GetXamlType(string xamlNamespace, string name, params XamlType[] typeArguments)
 		{
 			XamlType ret;
 			var key = Tuple.Create(xamlNamespace, name);

--- a/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
@@ -414,7 +414,7 @@ namespace Portable.Xaml
 
 			var n = xamlTypeName;
 			if (n.TypeArguments.Count == 0) // non-generic
-				return GetXamlType(n.Namespace, n.Name);
+				return GetXamlType(n.Namespace, n.Name, null);
 
 			// generic
 			XamlType[] typeArgs = new XamlType [n.TypeArguments.Count];

--- a/src/Test/System.Xaml/XamlSchemaContextTest.cs
+++ b/src/Test/System.Xaml/XamlSchemaContextTest.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
+using System.IO;
 #if PCL
 using Portable.Xaml.Markup;
 using Portable.Xaml;
@@ -338,6 +339,31 @@ namespace MonoTests.Portable.Xaml
 			var xm = xt.GetAttachableMember("SomeCollection");
 			Assert.IsNotNull(xm, "#2");
 			Assert.AreEqual(typeof(List<TestClass4>), xm.Type.UnderlyingType, "#3");
+		}
+
+		[Test]
+		public void PassesNullToGetXamlType_typeArguments_ForNoArguments()
+		{
+			var xml = File.ReadAllText(Compat.GetTestFile("Int32.xml")).UpdateXml();
+			var ctx = new TestGetXamlTypeArgumentsNull();
+			var reader = new XamlXmlReader(new StringReader(xml), ctx);
+			var writer = new XamlObjectWriter(ctx);
+
+			XamlServices.Transform(reader, writer);
+
+			Assert.True(ctx.Invoked);
+		}
+
+		private class TestGetXamlTypeArgumentsNull : XamlSchemaContext
+		{
+			public bool Invoked { get; set; }
+
+			protected override XamlType GetXamlType(string xamlNamespace, string name, params XamlType[] typeArguments)
+			{
+				Assert.IsNull(typeArguments);
+				Invoked = true;
+				return base.GetXamlType(xamlNamespace, name, typeArguments);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fix for compatibility with System.Xaml.

When there are 0 type arguments, null should be passed in the `typeArguments` parameter to `XamlSchemaContext.GetXamlType`.

Yes, this makes no sense.

Depends on #113 