### PR TITLE
Handle unknown types a little better

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
@@ -325,7 +325,7 @@ namespace Portable.Xaml
 			XamlTypeName xtn;
 			if (!XamlTypeName.TryParse (Name, nsResolver, out xtn))
 				throw Error ("Failed to parse type name '{0}'", Name);
-			Type = sctx.GetXamlType (xtn);
+			Type = sctx.GetXamlType (xtn) ?? new XamlType(xtn.Namespace, xtn.Name, null, sctx);
 
 			ParseArgument();
 			if (!Read('}'))

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -219,6 +219,11 @@ namespace Portable.Xaml
 
 		public override void WriteStartObject(XamlType xamlType)
 		{
+			if (xamlType.IsUnknown)
+			{
+				throw new XamlObjectWriterException($"Cannot create unknown type '{xamlType}'.");
+			}
+
 			if (deferredWriter != null)
 			{
 				deferredWriter.Writer.WriteStartObject(xamlType);

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2226,6 +2226,18 @@ namespace MonoTests.Portable.Xaml
 		}
 
 		[Test]
+		public void Write_UnknownType()
+		{
+			var sw = new StringWriter();
+			var xw = new XamlObjectWriter(sctx);
+			xw.WriteStartObject(xt3);
+			xw.WriteStartMember(xt3.GetMember("TestProp1"));
+
+			var ex = Assert.Throws<XamlObjectWriterException>(() => xw.WriteStartObject(new XamlType("unk", "unknown", null, sctx)));
+			Assert.AreEqual("Cannot create unknown type '{unk}unknown'.", ex.Message);
+		}
+
+		[Test]
 		public void Write_DictionaryKeyProperty()
 		{
 			var xw = new XamlObjectWriter(sctx);


### PR DESCRIPTION
When  a markup extension's type cannot be resolved, throw an `XamlObjectWriterException` (previously resulted in a `NullReferenceException`). To do this, return an unknown `XamlType` rather than null in `ParsedMarkupExtensionInfo.Parse`.
