### PR TITLE
Fix markup extension lookup behavior.

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
@@ -325,7 +325,7 @@ namespace Portable.Xaml
 			XamlTypeName xtn;
 			if (!XamlTypeName.TryParse (Name, nsResolver, out xtn))
 				throw Error ("Failed to parse type name '{0}'", Name);
-			Type = sctx.GetXamlType (xtn);
+			Type = sctx.GetXamlType (xtn) ?? new XamlType(xtn.Namespace, xtn.Name, null, sctx);
 
 			ParseArgument();
 			if (!Read('}'))

--- a/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
@@ -325,7 +325,11 @@ namespace Portable.Xaml
 			XamlTypeName xtn;
 			if (!XamlTypeName.TryParse (Name, nsResolver, out xtn))
 				throw Error ("Failed to parse type name '{0}'", Name);
-			Type = sctx.GetXamlType (xtn) ?? new XamlType(xtn.Namespace, xtn.Name, null, sctx);
+
+			var xtnFirst = new XamlTypeName(xtn.Namespace, xtn.Name + "Extension", xtn.TypeArguments);
+			Type = sctx.GetXamlType (xtnFirst) ??
+				sctx.GetXamlType(xtn) ??
+				new XamlType(xtn.Namespace, xtn.Name, null, sctx);
 
 			ParseArgument();
 			if (!Read('}'))

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -219,6 +219,11 @@ namespace Portable.Xaml
 
 		public override void WriteStartObject(XamlType xamlType)
 		{
+			if (xamlType.IsUnknown)
+			{
+				throw new XamlObjectWriterException($"Cannot create unknown type '{xamlType}'.");
+			}
+
 			if (deferredWriter != null)
 			{
 				deferredWriter.Writer.WriteStartObject(xamlType);

--- a/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
@@ -423,7 +423,7 @@ namespace Portable.Xaml
 			return GetXamlType(n.Namespace, n.Name, typeArgs);
 		}
 
-		protected internal virtual XamlType GetXamlType(string xamlNamespace, string name, params XamlType[] typeArguments)
+		protected virtual XamlType GetXamlType(string xamlNamespace, string name, params XamlType[] typeArguments)
 		{
 			XamlType ret;
 			var key = Tuple.Create(xamlNamespace, name);

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2226,6 +2226,18 @@ namespace MonoTests.Portable.Xaml
 		}
 
 		[Test]
+		public void Write_UnknownType()
+		{
+			var sw = new StringWriter();
+			var xw = new XamlObjectWriter(sctx);
+			xw.WriteStartObject(xt3);
+			xw.WriteStartMember(xt3.GetMember("TestProp1"));
+
+			var ex = Assert.Throws<XamlObjectWriterException>(() => xw.WriteStartObject(new XamlType("unk", "unknown", null, sctx)));
+			Assert.AreEqual("Cannot create unknown type '{unk}unknown'.", ex.Message);
+		}
+
+		[Test]
 		public void Write_DictionaryKeyProperty()
 		{
 			var xw = new XamlObjectWriter(sctx);


### PR DESCRIPTION
System.Xaml doesn't rely on the `XamlSchemaContext.GetXamlType` method to lookup both `Foo` and `FooExtension` when `"{Foo}"` is encountered: it queries first for `FooExtension` and then for `Foo`.

This is important if the `XamlSchemaContext.GetXamlType` is overridden and the overridden method does not call `base.GetXamlType` then Portable.Xaml can fail where System.Xaml succeeds.

Note that `GetXamlType` _does_ still need to perform the dual lookup, and no - this makes no sense either.

Depends on #113 
Depends on #116 