### PR TITLE
Fixing line information transfer from XmlReader to the XamlXmlReader

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -111,8 +111,7 @@ namespace Portable.Xaml
 			}
 		}
 
-		//int line, column;
-		bool lineinfo_was_given;
+		int line, column;
 
 		internal XamlObjectWriterSettings Settings
 		{
@@ -136,14 +135,13 @@ namespace Portable.Xaml
 
 		public bool ShouldProvideLineInfo
 		{
-			get { return lineinfo_was_given; }
+			get { return true; }
 		}
 
 		public void SetLineInfo(int lineNumber, int linePosition)
 		{
-			//			line = lineNumber;
-			//			column = linePosition;
-			lineinfo_was_given = true;
+			line = lineNumber;
+			column = linePosition;
 		}
 
 		public void Clear()
@@ -248,6 +246,13 @@ namespace Portable.Xaml
 				deferredWriter.DeferCount++;
 				return;
 			}
+
+			if (property.IsUnknown)
+				throw new XamlObjectWriterException($"Cannot set unknown member '{property}'")
+				{
+					LineNumber = line,
+					LinePosition = column
+				};
 
 			intl.WriteStartMember(property);
 

--- a/src/Portable.Xaml/Portable.Xaml/XamlServices.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlServices.cs
@@ -123,7 +123,15 @@ namespace Portable.Xaml
 			if (xamlReader.NodeType == XamlNodeType.None)
 				xamlReader.Read ();
 
+			var xamlLineInfo = xamlReader as IXamlLineInfo;
+			var xamlLineConsumer = xamlWriter as IXamlLineInfoConsumer;
+			var shouldSetLineInfo = xamlLineInfo != null && xamlLineConsumer != null && xamlLineConsumer.ShouldProvideLineInfo && xamlLineInfo.HasLineInfo;
+
 			while (!xamlReader.IsEof) {
+				if (shouldSetLineInfo)
+				{
+					xamlLineConsumer.SetLineInfo(xamlLineInfo.LineNumber, xamlLineInfo.LinePosition);
+				}
 				xamlWriter.WriteNode (xamlReader);
 				xamlReader.Read ();
 			}

--- a/src/Test/System.Xaml/XamlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlReaderTest.cs
@@ -46,6 +46,13 @@ namespace MonoTests.Portable.Xaml
 	[TestFixture]
 	public partial class XamlReaderTest
 	{
+		
+		XamlReader GetReader(string filename)
+		{
+			string xml = File.ReadAllText(Compat.GetTestFile(filename)).UpdateXml();
+			return new XamlXmlReader(XmlReader.Create(new StringReader(xml)), new XamlXmlReaderSettings { ProvideLineInfo = true });
+		}
+		
 		[Test]
 		public void ReadSubtree1 ()
 		{
@@ -101,6 +108,26 @@ namespace MonoTests.Portable.Xaml
 			Assert.AreEqual (XamlNodeType.EndObject, xr.NodeType, "#6-3");
 			Assert.IsFalse (sr.Read (), "#7");
 			Assert.AreEqual (XamlNodeType.None, xr.NodeType, "#7-2");
+		}
+		
+		[Test]
+		public void CheckReaderPosition()
+		{
+			using (var reader = GetReader("PropertyNotFound.xml"))
+			{
+				var lineInfo = reader as IXamlLineInfo;
+				while (reader.Read())
+				{
+					if (reader.NodeType == XamlNodeType.StartMember)
+					{
+						if (reader.Member.Name == "Baz")
+						{
+							Assert.AreEqual(1, lineInfo.LineNumber, "Wrong LineNumber");
+							Assert.AreEqual(13, lineInfo.LinePosition, "Wrong LinePosition");
+						}
+					}
+				}
+			}
 		}
 	}
 }

--- a/src/Test/XmlFiles/PropertyNotFound.xml
+++ b/src/Test/XmlFiles/PropertyNotFound.xml
@@ -1,0 +1,2 @@
+<TestClass4 Baz="{x:Null}" xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />


### PR DESCRIPTION
Hi there! This PR is a reworked https://github.com/cwensley/Portable.Xaml/pull/80 (pulled by @mterwoord, thanks for adding tests and base code!). I finding the cause of failing test. The XamlXmlReader worked that: 
1) Create list of Attributes and Members of instnace by reading through the underlied CompatibleXmlReader -> XmlReader that have correct line and position information.

2) After  analysing all Attr and Members the attributes converted to the members and add it, but the reader not in right position at the right moment.

What I do: I store information from XmlReader in the read moment and then pass it in right moment.

This is PR ready for review.