### PR TITLE
Using System.ComponentModel.ISupportInitialize in netstandard2.0

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml-netstandard2.0.csproj
+++ b/src/Portable.Xaml/Portable.Xaml-netstandard2.0.csproj
@@ -8,12 +8,12 @@
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\..\artifacts\core\Debug\</OutputPath>
-    <DefineConstants>TRACE;PCL;NETSTANDARD;DEBUG;HAS_TYPE_CONVERTER;HAS_CUSTOM_ATTRIBUTE_PROVIDER;NETSTANDARD2_0</DefineConstants>
+    <DefineConstants>TRACE;PCL;NETSTANDARD;DEBUG;HAS_TYPE_CONVERTER;HAS_CUSTOM_ATTRIBUTE_PROVIDER;NETSTANDARD2_0;HAS_ISUPPORT_INITIALIZE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <OutputPath>..\..\artifacts\core\Release\</OutputPath>
-    <DefineConstants>TRACE;PCL;NETSTANDARD;RELEASE;HAS_TYPE_CONVERTER;HAS_CUSTOM_ATTRIBUTE_PROVIDER;NETSTANDARD2_0</DefineConstants>
+    <DefineConstants>TRACE;PCL;NETSTANDARD;RELEASE;HAS_TYPE_CONVERTER;HAS_CUSTOM_ATTRIBUTE_PROVIDER;NETSTANDARD2_0;HAS_ISUPPORT_INITIALIZE</DefineConstants>
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
 </Project>

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -24,7 +24,13 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using Portable.Xaml.ComponentModel;
+
+#if HAS_ISUPPORT_INITIALIZE
+	using ISupportInitialize = System.ComponentModel.ISupportInitialize;
+#else
+	using ISupportInitialize = Portable.Xaml.ComponentModel.ISupportInitialize;
+#endif
+
 using System.Globalization;
 using System.Linq;
 using System.Reflection;

--- a/src/Test/Portable.Xaml-tests-netstandard2.0.csproj
+++ b/src/Test/Portable.Xaml-tests-netstandard2.0.csproj
@@ -11,13 +11,13 @@
   </PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 	  <OutputPath>..\..\artifacts\test\Debug\netstandard2.0</OutputPath>
-		<DefineConstants>TRACE;DEBUG;PCL259;PCL;NETSTANDARD;NETSTANDARD2_0;HAS_TYPE_CONVERTER;HAS_CUSTOM_ATTRIBUTE_PROVIDER</DefineConstants>
+		<DefineConstants>TRACE;DEBUG;PCL259;PCL;NETSTANDARD;NETSTANDARD2_0;HAS_TYPE_CONVERTER;HAS_CUSTOM_ATTRIBUTE_PROVIDER;HAS_ISUPPORT_INITIALIZE</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
 		<DebugType>
 		</DebugType>
 		<OutputPath>..\..\artifacts\test\Release\netstandard2.0</OutputPath>
-		<DefineConstants>TRACE;PCL259;PCL;NETSTANDARD;NETSTANDARD2_0;HAS_TYPE_CONVERTER;HAS_CUSTOM_ATTRIBUTE_PROVIDER</DefineConstants>
+		<DefineConstants>TRACE;PCL259;PCL;NETSTANDARD;NETSTANDARD2_0;HAS_TYPE_CONVERTER;HAS_CUSTOM_ATTRIBUTE_PROVIDER;HAS_ISUPPORT_INITIALIZE</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Portable.Xaml\Portable.Xaml-netstandard2.0.csproj" />

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -40,8 +40,15 @@ using System.Collections.Immutable;
 #endif
 
 #if NETSTANDARD || PCL
-using ISupportInitialize = Portable.Xaml.ComponentModel.ISupportInitialize;
+
+#if HAS_ISUPPORT_INITIALIZE
+	using ISupportInitialize = System.ComponentModel.ISupportInitialize;
+#else
+	using ISupportInitialize = Portable.Xaml.ComponentModel.ISupportInitialize;
+#endif
+
 using System.ComponentModel;
+
 #endif
 
 #if PCL

--- a/src/Test/System.Xaml/XamlTypeTest.cs
+++ b/src/Test/System.Xaml/XamlTypeTest.cs
@@ -40,7 +40,11 @@ using System.Xaml.Schema;
 
 using CategoryAttribute = NUnit.Framework.CategoryAttribute;
 #if NETSTANDARD
-using ISupportInitialize = Portable.Xaml.ComponentModel.ISupportInitialize;
+#if HAS_ISUPPORT_INITIALIZE
+	using ISupportInitialize = System.ComponentModel.ISupportInitialize;
+#else
+	using ISupportInitialize = Portable.Xaml.ComponentModel.ISupportInitialize;
+#endif
 using System.ComponentModel;
 #endif
 


### PR DESCRIPTION
Hi there!

Since netstandard2.0 to the System.ComponentModel adds the ISupportInitializer. We can support this and  instead depends on own implementatiom.

This PR adds the pre-compilation instruction HAS_ISUPPORT_INTIALIZE to the netstandard2.0 projects.