### PR TITLE
Proposal for collection handling like a System.Xaml

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
@@ -65,8 +65,24 @@ namespace Portable.Xaml
 
 		public ParsedMarkupExtensionInfo(ParsedMarkupExtensionInfo info)
 		{
-			this.value = info.value;
-			this.index = info.index;
+			//before creating new ParsedMarkupExtensionInfo with another ParsedMarkupExtensionInfo
+			//we must calculate bounds of our new pmei. Scan rest of string and search first true-close bracket 
+			int nastedExtensionsCount = 0;
+
+			for (int i = info.index + 1; i < info.value.Length; i++)
+			{
+				if (info.value[i] == '{') nastedExtensionsCount++;
+				if (info.value[i] == '}')
+					if (nastedExtensionsCount > 0)
+						nastedExtensionsCount--;
+					else
+					{
+						this.value = info.value.Substring(info.index, i - info.index + 1);
+						break;
+					}
+			}
+
+			this.index = 0;
 			this.nsResolver = info.nsResolver;
 			this.sctx = info.sctx;
 		}
@@ -95,7 +111,7 @@ namespace Portable.Xaml
 
 		string ReadUntil (char[] ch, bool readToEnd = false, bool skip = true, char? escape = null)
 		{
-			var endidx = IndexOfAnyEscaped (new char[] { '}' }, value, escape, index);
+			var endidx = value.Length;
 			var idx = IndexOfAnyEscaped (ch, value, escape, index);
 			string val = null;
 			if (idx >= 0 && idx <= endidx)
@@ -234,6 +250,12 @@ namespace Portable.Xaml
 			switch (Current)
 			{
 			case '{':
+				// escaped sequence
+				if (value.Length - 1 > index && value[index + 1] == '}')
+				{
+					index += 2;
+					return ReadUntil(',', true, escape: '\\');
+				}
 				var markup = ReadMarkup();
 				if (markup != null)
 				{
@@ -319,8 +341,12 @@ namespace Portable.Xaml
 
 		public void Parse ()
 		{
-			if (!Read('{'))
-				throw Error ("Invalid markup extension attribute. It should begin with '{{', but was {0}", value);
+			//Get all inside brackets
+			if (value.Length > 1 && (value[0] != '{' || value[value.Length-1] != '}'))
+			{
+				throw new XamlParseException("Invalid markup extension attribute. It should begin with '{{' and end with '}}'");
+			}
+			value = value.Substring(1, value.Length - 2);
 			Name = ReadUntil (' ', true);
 			XamlTypeName xtn;
 			if (!XamlTypeName.TryParse (Name, nsResolver, out xtn))
@@ -332,8 +358,6 @@ namespace Portable.Xaml
 				new XamlType(xtn.Namespace, xtn.Name, null, sctx);
 
 			ParseArgument();
-			if (!Read('}'))
-				throw Error ("Expected '}}' in the markup extension attribute: '{0}'", value);
 		}
 
 		static Exception Error (string format, params object[] args)

--- a/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
@@ -325,7 +325,7 @@ namespace Portable.Xaml
 			XamlTypeName xtn;
 			if (!XamlTypeName.TryParse (Name, nsResolver, out xtn))
 				throw Error ("Failed to parse type name '{0}'", Name);
-			Type = sctx.GetXamlType (xtn);
+			Type = sctx.GetXamlType (xtn) ?? new XamlType(xtn.Namespace, xtn.Name, null, sctx);
 
 			ParseArgument();
 			if (!Read('}'))

--- a/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
@@ -325,7 +325,11 @@ namespace Portable.Xaml
 			XamlTypeName xtn;
 			if (!XamlTypeName.TryParse (Name, nsResolver, out xtn))
 				throw Error ("Failed to parse type name '{0}'", Name);
-			Type = sctx.GetXamlType (xtn) ?? new XamlType(xtn.Namespace, xtn.Name, null, sctx);
+
+			var xtnFirst = new XamlTypeName(xtn.Namespace, xtn.Name + "Extension", xtn.TypeArguments);
+			Type = sctx.GetXamlType (xtnFirst) ??
+				sctx.GetXamlType(xtn) ??
+				new XamlType(xtn.Namespace, xtn.Name, null, sctx);
 
 			ParseArgument();
 			if (!Read('}'))

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -368,7 +368,7 @@ namespace Portable.Xaml
 			
 			//if the type is immutable then we need set value
 			if(!state.Type.IsImmutable)
-				object_states.Peek().IsValueProvidedByParent = true;
+				object_states.Peek().IsValueProvidedByInstance = true;
 			state.Value = instance;
 			state.IsInstantiated = true;
 			object_states.Push(state);
@@ -556,7 +556,7 @@ namespace Portable.Xaml
 			{
 				var state = object_states.Peek();
 				// won't be instantiated yet if dealing with a type that has no default constructor
-				if (state.IsInstantiated && !(state.IsValueProvidedByParent 
+				if (state.IsInstantiated && !(state.IsValueProvidedByInstance 
 												&& state.CurrentMember.Type.IsCollection))
 					SetValue(member, state.Value, value);
 			}

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -365,6 +365,10 @@ namespace Portable.Xaml
 				instance = state.Type.Invoker.ToMutable(instance);
 			if (instance == null)
 				throw new XamlObjectWriterException(String.Format("The value  for '{0}' property is null", xm.Name));
+			
+			//if the type is immutable then we need set value
+			if(!state.Type.IsImmutable)
+				object_states.Peek().IsValueProvidedByParent = true;
 			state.Value = instance;
 			state.IsInstantiated = true;
 			object_states.Push(state);
@@ -552,7 +556,8 @@ namespace Portable.Xaml
 			{
 				var state = object_states.Peek();
 				// won't be instantiated yet if dealing with a type that has no default constructor
-				if (state.IsInstantiated && !state.IsAlreadyAttachedToParent)
+				if (state.IsInstantiated && !(state.IsValueProvidedByParent 
+												&& state.CurrentMember.Type.IsCollection))
 					SetValue(member, state.Value, value);
 			}
 		}

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -219,6 +219,11 @@ namespace Portable.Xaml
 
 		public override void WriteStartObject(XamlType xamlType)
 		{
+			if (xamlType.IsUnknown)
+			{
+				throw new XamlObjectWriterException($"Cannot create unknown type '{xamlType}'.");
+			}
+
 			if (deferredWriter != null)
 			{
 				deferredWriter.Writer.WriteStartObject(xamlType);

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -111,8 +111,7 @@ namespace Portable.Xaml
 			}
 		}
 
-		//int line, column;
-		bool lineinfo_was_given;
+		int line, column;
 
 		internal XamlObjectWriterSettings Settings
 		{
@@ -136,14 +135,13 @@ namespace Portable.Xaml
 
 		public bool ShouldProvideLineInfo
 		{
-			get { return lineinfo_was_given; }
+			get { return true; }
 		}
 
 		public void SetLineInfo(int lineNumber, int linePosition)
 		{
-			//			line = lineNumber;
-			//			column = linePosition;
-			lineinfo_was_given = true;
+			line = lineNumber;
+			column = linePosition;
 		}
 
 		public void Clear()
@@ -253,6 +251,13 @@ namespace Portable.Xaml
 				deferredWriter.DeferCount++;
 				return;
 			}
+
+			if (property.IsUnknown)
+				throw new XamlObjectWriterException($"Cannot set unknown member '{property}'")
+				{
+					LineNumber = line,
+					LinePosition = column
+				};
 
 			intl.WriteStartMember(property);
 
@@ -567,7 +572,7 @@ namespace Portable.Xaml
 			try
 			{
 				if (!source.OnSetValue(target, member, value))
-					member.Invoker.SetValue(target, value);
+						member.Invoker.SetValue(target, value);
 			}
 			catch (Exception ex)
 			{

--- a/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
@@ -423,7 +423,7 @@ namespace Portable.Xaml
 			return GetXamlType(n.Namespace, n.Name, typeArgs);
 		}
 
-		protected internal virtual XamlType GetXamlType(string xamlNamespace, string name, params XamlType[] typeArguments)
+		protected virtual XamlType GetXamlType(string xamlNamespace, string name, params XamlType[] typeArguments)
 		{
 			XamlType ret;
 			var key = Tuple.Create(xamlNamespace, name);

--- a/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
@@ -414,7 +414,7 @@ namespace Portable.Xaml
 
 			var n = xamlTypeName;
 			if (n.TypeArguments.Count == 0) // non-generic
-				return GetXamlType(n.Namespace, n.Name);
+				return GetXamlType(n.Namespace, n.Name, null);
 
 			// generic
 			XamlType[] typeArgs = new XamlType [n.TypeArguments.Count];

--- a/src/Portable.Xaml/Portable.Xaml/XamlServices.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlServices.cs
@@ -123,7 +123,15 @@ namespace Portable.Xaml
 			if (xamlReader.NodeType == XamlNodeType.None)
 				xamlReader.Read ();
 
+			var xamlLineInfo = xamlReader as IXamlLineInfo;
+			var xamlLineConsumer = xamlWriter as IXamlLineInfoConsumer;
+			var shouldSetLineInfo = xamlLineInfo != null && xamlLineConsumer != null && xamlLineConsumer.ShouldProvideLineInfo && xamlLineInfo.HasLineInfo;
+
 			while (!xamlReader.IsEof) {
+				if (shouldSetLineInfo)
+				{
+					xamlLineConsumer.SetLineInfo(xamlLineInfo.LineNumber, xamlLineInfo.LinePosition);
+				}
 				xamlWriter.WriteNode (xamlReader);
 				xamlReader.Read ();
 			}

--- a/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
@@ -110,6 +110,8 @@ namespace Portable.Xaml
 			{
 				get { return WrittenProperties.Count > 0 ? WrittenProperties[WrittenProperties.Count - 1] : null; }
 			}
+
+			public bool IsAlreadyAttachedToParent { get; set; }
 		}
 
 		object IProvideValueTarget.TargetObject => object_states.Peek().Value;

--- a/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
@@ -79,6 +79,7 @@ namespace Portable.Xaml
 				public const int IsGetObject = 1 << 0;
 				public const int IsInstantiated = 1 << 1;
 				public const int IsXamlWriterCreated = 1 << 2;
+				public const int IsValueProvidedByInstance = 1 << 3;
 			}
 
 			public bool IsGetObject
@@ -97,7 +98,11 @@ namespace Portable.Xaml
 				set { _flags.Set(ObjectStateFlags.IsXamlWriterCreated, value); }
 			}
 
-			public bool IsValueProvidedByParent { get; set; }
+			public bool IsValueProvidedByInstance
+			{
+				get { return _flags.Get(ObjectStateFlags.IsValueProvidedByInstance) ?? false; }
+				set { _flags.Set(ObjectStateFlags.IsValueProvidedByInstance, value); }
+			}
 
 			public int PositionalParameterIndex = -1;
 

--- a/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
@@ -97,6 +97,8 @@ namespace Portable.Xaml
 				set { _flags.Set(ObjectStateFlags.IsXamlWriterCreated, value); }
 			}
 
+			public bool IsValueProvidedByParent { get; set; }
+
 			public int PositionalParameterIndex = -1;
 
 			public string FactoryMethod;

--- a/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
@@ -80,6 +80,7 @@ namespace Portable.Xaml
 				public const int IsInstantiated = 1 << 1;
 				public const int IsXamlWriterCreated = 1 << 2;
 				public const int IsValueProvidedByInstance = 1 << 3;
+				public const int IsAlreadyAttachedToParent = 1 << 4;
 			}
 
 			public bool IsGetObject
@@ -98,12 +99,24 @@ namespace Portable.Xaml
 				set { _flags.Set(ObjectStateFlags.IsXamlWriterCreated, value); }
 			}
 
+			/// <summary>
+			/// Show what the value was taken from object instance
+			/// </summary>
 			public bool IsValueProvidedByInstance
 			{
 				get { return _flags.Get(ObjectStateFlags.IsValueProvidedByInstance) ?? false; }
 				set { _flags.Set(ObjectStateFlags.IsValueProvidedByInstance, value); }
 			}
 
+			/// <summary>
+			/// Show what the value in object state is already attached to the parent
+			/// </summary>
+			public bool IsAlreadyAttachedToParent
+			{
+				get { return _flags.Get(ObjectStateFlags.IsAlreadyAttachedToParent) ?? false; }
+				set { _flags.Set(ObjectStateFlags.IsAlreadyAttachedToParent, value); }
+			}
+			
 			public int PositionalParameterIndex = -1;
 
 			public string FactoryMethod;
@@ -118,7 +131,7 @@ namespace Portable.Xaml
 				get { return WrittenProperties.Count > 0 ? WrittenProperties[WrittenProperties.Count - 1] : null; }
 			}
 
-			public bool IsAlreadyAttachedToParent { get; set; }
+			
 		}
 
 		object IProvideValueTarget.TargetObject => object_states.Peek().Value;

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -395,14 +395,16 @@ namespace MonoTests.Portable.Xaml
 	}
 	
 	[ContentProperty(nameof(Items))]
-	public class CollectionCannotBeAssigned
+	public class CollectionAssignnmentTest
 	{
-		readonly List<TestClass4> items = new List<TestClass4>();
+		List<TestClass4> items = new List<TestClass4>();
+
+		public bool Assigned { get; private set; }
 
 		public List<TestClass4> Items
 		{
 			get => items;
-			set => throw new Exception("This should not happen.");
+			set { items = value; Assigned = true; }
 		}
 	}
 

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -394,6 +394,38 @@ namespace MonoTests.Portable.Xaml
 		}
 	}
 
+  	[UsableDuringInitialization(true)]
+	public class TestClass8 : ISupportInitialize
+	{
+		private TestClass8 _bar;
+		
+		public int State { get; set; }
+		
+		public TestClass7 Foo { get; set; }
+		
+		public TestClass8 Bar
+		{
+			get => _bar;
+			set
+			{
+				_bar = value;
+				
+				//The value must be not initialized yet
+				Assert.IsNull(_bar.Foo);
+			}
+		}
+
+		public void BeginInit()
+		{
+			State++;
+		}
+
+		public void EndInit()
+		{
+			State--;
+		}
+	}
+	
 	[RuntimeNameProperty("TheName")]
 	public class TestClass5WithName : TestClass5
 	{

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -393,6 +393,18 @@ namespace MonoTests.Portable.Xaml
 			State--;
 		}
 	}
+	
+	[ContentProperty(nameof(Items))]
+	public class CollectionCannotBeAssigned
+	{
+		readonly List<TestClass4> items = new List<TestClass4>();
+
+		public List<TestClass4> Items
+		{
+			get => items;
+			set => throw new Exception("This should not happen.");
+		}
+	}
 
   	[UsableDuringInitialization(true)]
 	public class TestClass8 : ISupportInitialize
@@ -1322,7 +1334,7 @@ namespace MonoTests.Portable.Xaml
 		Four
 	}
 
-	[ContentProperty("ListOfItems")]
+	[ContentProperty(nameof(ListOfItems))]
 	public class CollectionContentProperty
 	{
 		public IList<SimpleClass> ListOfItems { get; set; }

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2344,5 +2344,18 @@ $@"<TestClass7
 			Assert.False(ReferenceEquals(result, result.Bar));
 
 		}
+		
+		
+		[Test]
+		public void CollectionShouldNotBeAssigned()
+		{
+			var xml = $@"
+<CollectionCannotBeAssigned xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'>
+    <TestClass4/>	
+</CollectionCannotBeAssigned>".UpdateXml();
+			var result = (CollectionCannotBeAssigned)XamlServices.Parse(xml);
+
+			Assert.AreEqual(1, result.Items.Count);
+		}
 	}
 }

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2295,5 +2295,54 @@ $@"<TestClass7
 
 			Assert.AreEqual(0, testClass.State);
 		}
+		
+		[Test]
+		public void TestIsUsableDuringInitializationCorrectUsingOnMemberStart()
+		{
+			//NOTE: The assertion are happen in the TestClass8! Here just invoking methods 
+		
+			XamlSchemaContext context = new XamlSchemaContext();
+		
+			XamlObjectWriterSettings xows = new XamlObjectWriterSettings();
+
+			XamlObjectWriter ow = new XamlObjectWriter(context, xows);
+		
+			var xamlType = new XamlType(typeof(TestClass8),context);
+			var xamlType2 = new XamlType(typeof(TestClass7),context);
+			
+			Assert.IsTrue(xamlType.IsUsableDuringInitialization);
+			
+			var xamlMemberFoo = xamlType.GetMember("Foo");
+			var xamlMemberBar = xamlType.GetMember("Bar");
+			
+			ow.WriteStartObject(xamlType);
+			
+			ow.WriteStartMember(xamlMemberFoo);
+			ow.WriteStartObject(xamlType2);
+			ow.WriteEndObject();
+			ow.WriteEndMember();
+			
+			ow.WriteStartMember(xamlMemberBar);
+			
+			ow.WriteStartObject(xamlType);
+			ow.WriteStartMember(xamlMemberFoo);
+			
+			ow.WriteStartObject(xamlType2);
+			ow.WriteEndObject();
+			
+			ow.WriteEndMember();
+			
+			ow.WriteEndObject();
+		
+			ow.WriteEndMember();
+			ow.WriteEndObject();
+
+			var result = (TestClass8)ow.Result;
+			Assert.True(result.Foo != null);
+			Assert.True(result.Bar != null);
+			Assert.True(result.Bar.Foo != null);
+			Assert.False(ReferenceEquals(result, result.Bar));
+
+		}
 	}
 }

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2226,6 +2226,18 @@ namespace MonoTests.Portable.Xaml
 		}
 
 		[Test]
+		public void Write_UnknownType()
+		{
+			var sw = new StringWriter();
+			var xw = new XamlObjectWriter(sctx);
+			xw.WriteStartObject(xt3);
+			xw.WriteStartMember(xt3.GetMember("TestProp1"));
+
+			var ex = Assert.Throws<XamlObjectWriterException>(() => xw.WriteStartObject(new XamlType("unk", "unknown", null, sctx)));
+			Assert.AreEqual("Cannot create unknown type '{unk}unknown'.", ex.Message);
+		}
+
+		[Test]
 		public void Write_DictionaryKeyProperty()
 		{
 			var xw = new XamlObjectWriter(sctx);

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2350,12 +2350,45 @@ $@"<TestClass7
 		public void CollectionShouldNotBeAssigned()
 		{
 			var xml = $@"
-<CollectionCannotBeAssigned xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'>
+<CollectionAssignnmentTest xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'>
     <TestClass4/>	
-</CollectionCannotBeAssigned>".UpdateXml();
-			var result = (CollectionCannotBeAssigned)XamlServices.Parse(xml);
+</CollectionAssignnmentTest>".UpdateXml();
+			var result = (CollectionAssignnmentTest)XamlServices.Parse(xml);
 
+			Assert.False(result.Assigned);
 			Assert.AreEqual(1, result.Items.Count);
+		}
+
+		[Test]
+		public void CollectionShouldNotBeAssigned2()
+		{
+			var xml = $@"
+<CollectionAssignnmentTest xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'>
+    <TestClass4/>	
+    <TestClass4/>	
+</CollectionAssignnmentTest>".UpdateXml();
+			var result = (CollectionAssignnmentTest)XamlServices.Parse(xml);
+
+			Assert.False(result.Assigned);
+			Assert.AreEqual(2, result.Items.Count);
+		}
+
+		[Test]
+		public void CollectionShouldBeAssigned()
+		{
+			var xml = $@"
+<CollectionAssignnmentTest xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'
+					  	   xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+						   xmlns:scg='clr-namespace:System.Collections.Generic;assembly=mscorlib'>
+	<scg:List x:TypeArguments='TestClass4'>
+		<TestClass4/>	
+		<TestClass4/>	
+	</scg:List>
+</CollectionAssignnmentTest>".UpdateXml();
+			var result = (CollectionAssignnmentTest)XamlServices.Parse(xml);
+
+			Assert.True(result.Assigned);
+			Assert.AreEqual(2, result.Items.Count);
 		}
 	}
 }

--- a/src/Test/System.Xaml/XamlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlReaderTest.cs
@@ -46,6 +46,13 @@ namespace MonoTests.Portable.Xaml
 	[TestFixture]
 	public partial class XamlReaderTest
 	{
+		
+		XamlReader GetReader(string filename)
+		{
+			string xml = File.ReadAllText(Compat.GetTestFile(filename)).UpdateXml();
+			return new XamlXmlReader(XmlReader.Create(new StringReader(xml)), new XamlXmlReaderSettings { ProvideLineInfo = true });
+		}
+		
 		[Test]
 		public void ReadSubtree1 ()
 		{
@@ -101,6 +108,26 @@ namespace MonoTests.Portable.Xaml
 			Assert.AreEqual (XamlNodeType.EndObject, xr.NodeType, "#6-3");
 			Assert.IsFalse (sr.Read (), "#7");
 			Assert.AreEqual (XamlNodeType.None, xr.NodeType, "#7-2");
+		}
+		
+		[Test]
+		public void CheckReaderPosition()
+		{
+			using (var reader = GetReader("PropertyNotFound.xml"))
+			{
+				var lineInfo = reader as IXamlLineInfo;
+				while (reader.Read())
+				{
+					if (reader.NodeType == XamlNodeType.StartMember)
+					{
+						if (reader.Member.Name == "Baz")
+						{
+							Assert.AreEqual(1, lineInfo.LineNumber, "Wrong LineNumber");
+							Assert.AreEqual(13, lineInfo.LinePosition, "Wrong LinePosition");
+						}
+					}
+				}
+			}
 		}
 	}
 }

--- a/src/Test/System.Xaml/XamlSchemaContextTest.cs
+++ b/src/Test/System.Xaml/XamlSchemaContextTest.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
+using System.IO;
 #if PCL
 using Portable.Xaml.Markup;
 using Portable.Xaml;
@@ -338,6 +339,31 @@ namespace MonoTests.Portable.Xaml
 			var xm = xt.GetAttachableMember("SomeCollection");
 			Assert.IsNotNull(xm, "#2");
 			Assert.AreEqual(typeof(List<TestClass4>), xm.Type.UnderlyingType, "#3");
+		}
+
+		[Test]
+		public void PassesNullToGetXamlType_typeArguments_ForNoArguments()
+		{
+			var xml = File.ReadAllText(Compat.GetTestFile("Int32.xml")).UpdateXml();
+			var ctx = new TestGetXamlTypeArgumentsNull();
+			var reader = new XamlXmlReader(new StringReader(xml), ctx);
+			var writer = new XamlObjectWriter(ctx);
+
+			XamlServices.Transform(reader, writer);
+
+			Assert.True(ctx.Invoked);
+		}
+
+		private class TestGetXamlTypeArgumentsNull : XamlSchemaContext
+		{
+			public bool Invoked { get; set; }
+
+			protected override XamlType GetXamlType(string xamlNamespace, string name, params XamlType[] typeArguments)
+			{
+				Assert.IsNull(typeArguments);
+				Invoked = true;
+				return base.GetXamlType(xamlNamespace, name, typeArguments);
+			}
 		}
 	}
 }

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -522,7 +522,103 @@ namespace MonoTests.Portable.Xaml
 			Read_CustomExtensionWithCommasInPositionalValue(r);
 		}
 
-        [Test]
+		[Test]
+		public void Read_CustomExtensionWithStringFormat()
+		{
+			var r = GetReaderText(@"<ValueWrapper 
+	StringValue='{MyExtension2 Bar=Hello {0}}' 
+	xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+	xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'/>");
+
+			r.Read(); // ns
+			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, r.NodeType);
+			r.Read(); // ns
+			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, r.NodeType);
+			r.Read();
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+			var xt = r.Type;
+			Assert.AreEqual(r.SchemaContext.GetXamlType(typeof(ValueWrapper)), xt);
+
+			if (r is XamlXmlReader)
+				ReadBase(r);
+
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual(xt.GetMember("StringValue"), r.Member);
+			Assert.IsTrue(r.Read(), "#5");
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+			Assert.AreEqual(r.SchemaContext.GetXamlType(typeof(MyExtension2)), xt = r.Type);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual(xt.GetMember("Bar"), r.Member);
+
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
+			Assert.AreEqual("Hello {0}", r.Value);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			Assert.IsFalse(r.Read());
+			Assert.AreEqual(XamlNodeType.None, r.NodeType);
+			Assert.IsTrue(r.IsEof);
+		}
+
+		[Test]
+		public void Read_CustomExtensionWithStringFormatEscape()
+		{
+			var r = GetReaderText(@"<ValueWrapper 
+	StringValue='{MyExtension2 Bar={}{0} Hello}' 
+	xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+	xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'/>");
+
+			r.Read(); // ns
+			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, r.NodeType);
+			r.Read(); // ns
+			Assert.AreEqual(XamlNodeType.NamespaceDeclaration, r.NodeType);
+			r.Read();
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+			var xt = r.Type;
+			Assert.AreEqual(r.SchemaContext.GetXamlType(typeof(ValueWrapper)), xt);
+
+			if (r is XamlXmlReader)
+				ReadBase(r);
+
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual(xt.GetMember("StringValue"), r.Member);
+			Assert.IsTrue(r.Read(), "#5");
+			Assert.AreEqual(XamlNodeType.StartObject, r.NodeType);
+			Assert.AreEqual(r.SchemaContext.GetXamlType(typeof(MyExtension2)), xt = r.Type);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.StartMember, r.NodeType);
+			Assert.AreEqual(xt.GetMember("Bar"), r.Member);
+
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.Value, r.NodeType);
+			Assert.AreEqual("{0} Hello", r.Value);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndMember, r.NodeType);
+			Assert.IsTrue(r.Read());
+			Assert.AreEqual(XamlNodeType.EndObject, r.NodeType);
+
+			Assert.IsFalse(r.Read());
+			Assert.AreEqual(XamlNodeType.None, r.NodeType);
+			Assert.IsTrue(r.IsEof);
+		}
+
+		[Test]
         public void Load_CustomExtensionWithEscapeChars()
         {
             var r = GetReader("CustomExtensionWithEscapeChars.xml");

--- a/src/Test/XmlFiles/PropertyNotFound.xml
+++ b/src/Test/XmlFiles/PropertyNotFound.xml
@@ -1,0 +1,2 @@
+<TestClass4 Baz="{x:Null}" xmlns="clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />


### PR DESCRIPTION
Hi there. Where the proposal for fixing different collection handling in portable.xaml and system.xaml.

The root of the problem:

Then the collection contains single element the system.xaml not re-assign this property (Check added test and just add the elements to the collection in the xml representation)

Portable.Xaml now working like this:

We are have collection with 1 element.
On parsing stage we add the GetObject xaml node and go through the StartGetObject in the InternalXamlObjectWriter there we read the reference of the current collection(initialized or not) after that we are save it into the ObjectState. Then we end populating the collection we are _re-assign_ it. 

I try to read specs and documentation from ms but I not found any useful information about this question, why the collection property must not reassign then the elements count = 1 and must assing then elements count > 1.

I write the fixes to make portable.xaml like a system.xaml behavour. This changes so suspect because: 
1) I'm not realize how _must_ work xaml engine
2) I not found the docs about this
3) My programmer skill not high yet.

Can anyone help and explain what direction to take?

Thanks in advice.