### PR TITLE
WIP: Use type converter even for matching types

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -688,23 +688,15 @@ namespace Portable.Xaml
 				if (ReferenceEquals(xt, null))
 					return value;
 
-				// Not sure if this is really required though...
-				var vt = sctx.GetXamlType(value.GetType());
-				if (vt.CanAssignTo(xt))
-					return value;
-
 				// FIXME: this could be generalized by some means, but I cannot find any.
 				if (xt.UnderlyingType == typeof(XamlType) && value is string)
 					value = ResolveTypeFromName((string)value);
 
 				// FIXME: this could be generalized by some means, but I cannot find any.
-				if (xt.UnderlyingType == typeof(Type))
-					value = new TypeExtension((string)value).ProvideValue(service_provider);
+				if (xt.UnderlyingType == typeof(Type) && value is string s)
+					value = new TypeExtension(s).ProvideValue(service_provider);
 				if (ReferenceEquals(xt, XamlLanguage.Type) && value is string)
 					value = new TypeExtension((string)value);
-
-				if (IsAllowedType(xt, value))
-					return value;
 
 				var xtc = xm?.TypeConverter ?? xt.TypeConverter;
 				if (xtc != null && value != null)
@@ -714,6 +706,9 @@ namespace Portable.Xaml
 						value = tc.ConvertFrom(service_provider, CultureInfo.InvariantCulture, value);
 					return value;
 				}
+
+				if (IsAllowedType(xt, value))
+					return value;
 			}
 			catch (Exception ex)
 			{

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -1808,6 +1808,18 @@ namespace MonoTests.Portable.Xaml
 	{
 		public object Key { get; set; }
 	}
+
+	public class PrependFooConverter : TypeConverter
+	{
+		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) => true;
+		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) => "Foo" + value.ToString();
+	}
+
+	public class TypeConverterUsed
+	{
+		[TypeConverter(typeof(PrependFooConverter))]
+		public string Value { get; set; }
+	}
 }
 
 namespace XamlTest

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2344,5 +2344,17 @@ $@"<TestClass7
 			Assert.False(ReferenceEquals(result, result.Bar));
 
 		}
+
+		[Test]
+		public void TypeConverterIsUsedEvenIfMatchingType()
+		{
+			var xml =
+$@"<TypeConverterUsed 
+		xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0' 
+		Value='Bar' />".UpdateXml();
+			var result = (TypeConverterUsed)XamlServices.Parse(xml);
+
+			Assert.AreEqual("FooBar", result.Value);
+		}
 	}
 }


### PR DESCRIPTION
Previously, if a type converter was applied to a property of e.g. type `string` or `object` then that type converter would never be invoked because the value to be assigned is already of `string`/`object`. This is not System.Xaml's behavior as shown by the `TypeConverterIsUsedEvenIfMatchingType`.

However, fixing this behavior made the `ComplexPositionalParameterWrapper` fail because an exception is no longer thrown. I can't work out _why_ the exception should be thrown here - the `ComplexPositionalParameterWrapper.xml` file looks like correct XAML.

@cwensley any idea what's going on here?