### PR TITLE
Fix markup extension parsing

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
@@ -315,7 +315,7 @@ namespace Portable.Xaml
 			var info = new ParsedMarkupExtensionInfo (this);
 			try {
 				info.Parse ();
-				index = info.index;
+				index += info.index;
 				return info;
 			} catch {
 			}

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -645,6 +645,30 @@ namespace MonoTests.Portable.Xaml
 		}
 	}
 
+	[TypeConverter(typeof(StringConverter))]
+	public class MyExtension8 : MarkupExtension
+	{
+		public MyExtension8()
+		{
+		}
+
+		public MyExtension8(string arg1)
+		{
+			Foo = arg1;
+		}
+
+		[ConstructorArgument("arg1")]
+		public string Foo { get; set; }
+
+		[ConstructorArgument("arg2")]
+		public Type Bar { get; set; }
+
+		public override object ProvideValue(IServiceProvider provider)
+		{
+			return "provided_value";
+		}
+	}
+
 	/// <summary>
 	/// Returns first ambient value matching provided key.
 	/// </summary>

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -640,6 +640,18 @@ namespace MonoTests.Portable.Xaml
 		}
 
 		[Test]
+		public void Read_CustomExtensionWithPositionalAndNamedWithChild()
+		{
+			var xml = @"
+<ValueWrapper 
+	StringValue='{MyExtension8 SomeValue, Bar={x:Type x:String}}' 
+	xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+	xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0' />
+".UpdateXml();
+			var result = (ValueWrapper)XamlServices.Parse(xml);
+		}
+
+		[Test]
 		public void Read_CustomExtensionWithPositonalAfterExplicitProperty()
 		{
 			// cannot have positional property after named property


### PR DESCRIPTION
A positional argument, followed by a named argument with a value of another markup extension fails.

Fixes #125.