### PR TITLE
Fix for IsUsableDuringInitialization bug

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -471,12 +471,12 @@ namespace Portable.Xaml
 						var parent_state = object_states.Peek();
 						object_states.Push(state);
 
-						if (!parent_state.IsAlreadyAttachedToParent && parent_state.CurrentMember != null &&
-						    parent_state.Type.IsUsableDuringInitialization &&
+						if (parent_state.CurrentMember != null &&
+						    state.Type.IsUsableDuringInitialization &&
 						    !(parent_state.Type.IsCollection || parent_state.Type.IsDictionary))
 						{
 							SetValue(parent_state.CurrentMember, parent_state.Value, state.Value);
-							parent_state.IsAlreadyAttachedToParent = true;
+							parent_state.CurrentMemberState.IsAlreadySet = true;
 						}
 					}
 				}
@@ -552,7 +552,7 @@ namespace Portable.Xaml
 			{
 				var state = object_states.Peek();
 				// won't be instantiated yet if dealing with a type that has no default constructor
-				if (state.IsInstantiated && !state.IsAlreadyAttachedToParent)
+				if (state.IsInstantiated && !state.CurrentMemberState.IsAlreadySet)
 					SetValue(member, state.Value, value);
 			}
 		}

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -471,8 +471,8 @@ namespace Portable.Xaml
 						var parent_state = object_states.Peek();
 						object_states.Push(state);
 
-						if (parent_state.CurrentMember != null &&
-						    state.Type.IsUsableDuringInitialization &&
+						if (state.Type.IsUsableDuringInitialization &&
+						    parent_state.CurrentMemberState?.IsAlreadySet == false &&
 						    !(parent_state.Type.IsCollection || parent_state.Type.IsDictionary))
 						{
 							SetValue(parent_state.CurrentMember, parent_state.Value, state.Value);

--- a/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
@@ -110,8 +110,6 @@ namespace Portable.Xaml
 			{
 				get { return WrittenProperties.Count > 0 ? WrittenProperties[WrittenProperties.Count - 1] : null; }
 			}
-
-			public bool IsAlreadyAttachedToParent { get; set; }
 		}
 
 		object IProvideValueTarget.TargetObject => object_states.Peek().Value;
@@ -130,6 +128,7 @@ namespace Portable.Xaml
 			public XamlMember Member;
 			public object Value;
 			public AllowedMemberLocations OccuredAs = AllowedMemberLocations.None;
+			public bool IsAlreadySet;
 		}
 
 		public virtual void CloseAll()

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -394,35 +394,45 @@ namespace MonoTests.Portable.Xaml
 		}
 	}
 
-  	[UsableDuringInitialization(true)]
-	public class TestClass8 : ISupportInitialize
+	public class TestClass8
 	{
-		private TestClass8 _bar;
-		
-		public int State { get; set; }
-		
-		public TestClass7 Foo { get; set; }
-		
-		public TestClass8 Bar
+		private TestClass9 _bar;
+
+		public TestClass9 Bar
 		{
 			get => _bar;
 			set
 			{
+				// Make sure we don't set this value twice.
+				Assert.IsNull(_bar);
+
 				_bar = value;
 				
-				//The value must be not initialized yet
+				// The value must be instantiated, but not yet initialized.
+				Assert.IsFalse(_bar.IsInitialized);
 				Assert.IsNull(_bar.Foo);
 			}
 		}
+	}
 
+  	[UsableDuringInitialization(true)]
+	public class TestClass9 : ISupportInitialize
+	{
+		public TestClass7 Foo { get; set; }
+
+		public bool IsInitialized { get; private set;}
+
+		/// <inheritdoc />
 		public void BeginInit()
 		{
-			State++;
+			Assert.IsFalse(IsInitialized);
 		}
 
+		/// <inheritdoc />
 		public void EndInit()
 		{
-			State--;
+			Assert.IsFalse(IsInitialized);
+			IsInitialized = true;
 		}
 	}
 	

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -420,6 +420,8 @@ namespace MonoTests.Portable.Xaml
 	{
 		public TestClass7 Foo { get; set; }
 
+		public string Baz { get; set; }
+
 		public bool IsInitialized { get; private set;}
 
 		/// <inheritdoc />

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2317,8 +2317,9 @@ $@"<TestClass7
 			Assert.IsTrue(childXamlType.IsUsableDuringInitialization);
 			
 			var xamlMemberFoo = childXamlType.GetMember(nameof(TestClass9.Foo));
+			var xamlMemberBaz = childXamlType.GetMember(nameof(TestClass9.Baz));
 			var xamlMemberBar = parentXamlType.GetMember(nameof(TestClass8.Bar));
-			
+
 			ow.WriteStartObject(parentXamlType);
 			ow.WriteStartMember(xamlMemberBar);
 
@@ -2326,6 +2327,9 @@ $@"<TestClass7
 			ow.WriteStartMember(xamlMemberFoo);
 			ow.WriteStartObject(xamlMemberFoo.Type);
 			ow.WriteEndObject();
+			ow.WriteEndMember();
+			ow.WriteStartMember(xamlMemberBaz);
+			ow.WriteValue("Test");
 			ow.WriteEndMember();
 			ow.WriteEndObject();
 
@@ -2335,6 +2339,7 @@ $@"<TestClass7
 			var result = (TestClass8)ow.Result;
 			Assert.IsTrue(result.Bar.IsInitialized);
 			Assert.IsNotNull(result.Bar.Foo);
+			Assert.AreEqual(result.Bar.Baz, "Test");
 		}
 	}
 }


### PR DESCRIPTION
This is to fix a bug in `IsUsableDuringInitialization` implementation that has been merged in scope of #110. In `XamlObjectWriterInternal.OnWriteStartMember`, we should check the `IsUsableDuringInitialization` flag of the _current_ `ObjectState`, not the parent one. And `ObjectState` isn't a good place for the `IsAlreadyAttachedToParent` flag, since its going to affect other members of an object, which caused the `void SetValue(XamlMember member, object value)` method to skip subsequent values.

In general, we should't even care about the `IsUsableDuringInitialization` flag of the parent class when constructing a child object. The goal is to attach the current object to a parent (if any) as soon as possible, but only if the current class is marked as `IsUsableDuringInitialization`.

The aforementioned bug could be easily reproduced if you remove the `UsableDuringInitialization(true)` attribute from the parent class, but leave it on the child class. In this case, the child object would be attached only _after_ initialization.