### PR TITLE
Support for UsableDuringInitialization types inside collections

### DIFF
--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -437,6 +437,27 @@ namespace MonoTests.Portable.Xaml
 			IsInitialized = true;
 		}
 	}
+
+	[ContentProperty(nameof(Items))]
+	public class TestClass10
+	{
+		public TestClass10()
+		{
+			var collection = new ObservableCollection<TestClass9>();
+			collection.CollectionChanged += (sender, args) =>
+			{
+				foreach (TestClass9 item in args.NewItems)
+				{
+					Assert.IsFalse(item.IsInitialized);
+					Assert.IsNull(item.Baz);
+				}
+			};
+
+			Items = collection;
+		}
+
+		public IList<TestClass9> Items { get; }
+	}
 	
 	[ContentProperty(nameof(Items))]
 	public class CollectionAssignnmentTest

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2347,13 +2347,17 @@ $@"<TestClass7
 		{
 			string xml =
 				@"<TestClass10 xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'>
-					<TestClass9 Baz='Test'/>
+					<TestClass9 Baz='Test1'/>
+					<TestClass9 Baz='Test2'/>
+					<TestClass9/>
 				  </TestClass10>".UpdateXml();
 
 			// Note: The most important assert is invoked inside the TestClass10 (CollectionChanged).
 			var result = (TestClass10)XamlServices.Parse(xml);
-			Assert.AreEqual(result.Items.Count, 1);
-			Assert.AreEqual(result.Items[0].Baz, "Test");
+			Assert.AreEqual(3, result.Items.Count);
+			Assert.AreEqual("Test1", result.Items[0].Baz);
+			Assert.AreEqual("Test2", result.Items[1].Baz);
+			Assert.IsNull(result.Items[2].Baz);
 		}
 		
 		[Test]

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2341,6 +2341,20 @@ $@"<TestClass7
 			Assert.IsNotNull(result.Bar.Foo);
 			Assert.AreEqual(result.Bar.Baz, "Test");
 		}
+
+		[Test]
+		public void TestIsUsableDuringInitializationWithCollection()
+		{
+			string xml =
+				@"<TestClass10 xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'>
+					<TestClass9 Baz='Test'/>
+				  </TestClass10>".UpdateXml();
+
+			// Note: The most important assert is invoked inside the TestClass10 (CollectionChanged).
+			var result = (TestClass10)XamlServices.Parse(xml);
+			Assert.AreEqual(result.Items.Count, 1);
+			Assert.AreEqual(result.Items[0].Baz, "Test");
+		}
 		
 		[Test]
 		public void CollectionShouldNotBeAssigned()


### PR DESCRIPTION
`UsableDuringInitialization` types should be attached to parent collections (such as `x:Items`) before being initialized, as it is for regular, non-collection properties. So this is what this fix does.