### PR TITLE
Should serialize object

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml.ComponentModel/ShouldSerializeAttribute.cs
+++ b/src/Portable.Xaml/Portable.Xaml.ComponentModel/ShouldSerializeAttribute.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Portable.Xaml.ComponentModel
+{
+	/// <summary>
+	/// This attribute defines method, which responcible for object serialization.
+	/// The method have to returns bool type and hasn't arguments.
+	/// </summary>
+	public class ShouldSerializeAttribute : Attribute
+	{
+		public ShouldSerializeAttribute(string methodName)
+		{
+			MethodName = methodName;
+		}
+		
+		/// <summary>
+		/// Method name which will responce for serialization
+		/// </summary>
+		public string MethodName { get; set; }
+	}
+}

--- a/src/Portable.Xaml/Portable.Xaml.ComponentModel/ShouldSerializeAttribute.cs
+++ b/src/Portable.Xaml/Portable.Xaml.ComponentModel/ShouldSerializeAttribute.cs
@@ -6,6 +6,7 @@ namespace Portable.Xaml.ComponentModel
 	/// This attribute defines method, which responcible for object serialization.
 	/// The method have to returns bool type and hasn't arguments.
 	/// </summary>
+	[EnhancedXaml]
 	public class ShouldSerializeAttribute : Attribute
 	{
 		public ShouldSerializeAttribute(string methodName)

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectNodeIterator.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectNodeIterator.cs
@@ -101,6 +101,9 @@ namespace Portable.Xaml
 
 		IEnumerable<XamlNodeInfo> GetNodes(XamlMember xm, XamlObject xobj, XamlType overrideMemberType = null, bool partOfPositionalParameters = false, XamlNodeInfo node = null)
 		{
+			//If the item is invisible for the serialization then we must just skip it and return empty nodes info
+			if (!xobj.Type.ShouldSerialize(xobj.Value)) yield break;
+
 			object val;
 			// Value - only for non-top-level node (thus xm != null)
 			if (xm != null)

--- a/src/Portable.Xaml/Portable.Xaml/XamlType.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlType.cs
@@ -1053,6 +1053,7 @@ namespace Portable.Xaml
 		/// <summary>
 		/// Visability object during serialization. This property lookup attribute <see cref="System.ComponentModel.DesignerSerializationVisibilityAttribute"/>
 		/// </summary>
+		[EnhancedXaml]
 		public DesignerSerializationVisibility SerializationVisibility
 		{
 			get

--- a/src/Portable.Xaml/Portable.Xaml/XamlType.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlType.cs
@@ -1092,15 +1092,19 @@ namespace Portable.Xaml
 		/// <returns>Method info if method found and null if not</returns>
 		MethodInfo LookupShouldSerializeMethod()
 		{
-			var methods = UnderlyingType?.GetTypeInfo().GetDeclaredMethods("ShouldSerialize");
-			if (methods != null)
-				foreach (var method in methods)
-				{
-					if (method.GetParameters().Length == 0 && method.ReturnType == typeof(bool))
+			var attr = this.CustomAttributeProvider.GetCustomAttribute<ShouldSerializeAttribute>(false);
+			if (attr != null)
+			{
+				var methods = UnderlyingType?.GetTypeInfo().GetDeclaredMethods(attr.MethodName);
+				if (methods != null)
+					foreach (var method in methods)
 					{
-						return method;
+						if (method.GetParameters().Length == 0 && method.ReturnType == typeof(bool))
+						{
+							return method;
+						}
 					}
-				}
+			}
 
 			return null;
 		}

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -437,7 +437,42 @@ namespace MonoTests.Portable.Xaml
 			IsInitialized = true;
 		}
 	}
-	
+
+	public class ShouldSerializeInvisibleTest
+	{
+		private string _value;
+
+		public string Value
+		{
+			get  =>  $"This is {((IsVisibleInXml)?"":"in")}visible";
+			set => _value = value;
+		}
+
+		/// <summary>
+		/// This is invisible by default
+		/// </summary>
+		public bool IsVisibleInXml { get; set; } = false;
+
+		public bool ShouldSerialize()
+		{
+			return IsVisibleInXml;
+		}
+	}
+
+	public class ShouldSerializeInCollectionTest
+	{
+		public ShouldSerializeInCollectionTest()
+		{
+			Collection = new List<ShouldSerializeInvisibleTest>();
+			Collection.Add(new ShouldSerializeInvisibleTest());
+			Collection.Add(new ShouldSerializeInvisibleTest() {IsVisibleInXml = true});
+			Collection.Add(new ShouldSerializeInvisibleTest());
+			Collection.Add(new ShouldSerializeInvisibleTest() {IsVisibleInXml = true});
+		}
+		
+		public List<ShouldSerializeInvisibleTest> Collection { get; set; }
+	}
+
 	[ContentProperty(nameof(Items))]
 	public class CollectionAssignnmentTest
 	{

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -459,7 +459,9 @@ namespace MonoTests.Portable.Xaml
 		public IList<TestClass9> Items { get; }
 	}
 	
-
+#if PCL
+	[ShouldSerializeAttribute(nameof(CustomShouldSerializeMethod))]
+#endif
 	public class ShouldSerializeInvisibleTest
 	{
 		private string _value;
@@ -475,7 +477,7 @@ namespace MonoTests.Portable.Xaml
 		/// </summary>
 		public bool IsVisibleInXml { get; set; } = false;
 
-		public bool ShouldSerialize()
+		public bool CustomShouldSerializeMethod()
 		{
 			return IsVisibleInXml;
 		}

--- a/src/Test/System.Xaml/XamlXmlWriterTest.cs
+++ b/src/Test/System.Xaml/XamlXmlWriterTest.cs
@@ -1261,7 +1261,7 @@ namespace MonoTests.Portable.Xaml
 			}
 			else
 			{
-				var xaml = @"<ShouldSerializeInCollectionTest xmlns=""clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_netstandard20"" xmlns:scg=""clr-namespace:System.Collections.Generic;assembly=mscorlib"" xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+				var xaml = @"<ShouldSerializeInCollectionTest xmlns=""clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_5"" xmlns:scg=""clr-namespace:System.Collections.Generic;assembly=mscorlib"" xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
   <ShouldSerializeInCollectionTest.Collection>
     <scg:List x:TypeArguments=""ShouldSerializeInvisibleTest"" Capacity=""4"">
       <ShouldSerializeInvisibleTest IsVisibleInXml=""True"" Value=""This is visible"" />

--- a/src/Test/System.Xaml/XamlXmlWriterTest.cs
+++ b/src/Test/System.Xaml/XamlXmlWriterTest.cs
@@ -1235,6 +1235,46 @@ namespace MonoTests.Portable.Xaml
 
 			Assert.AreEqual(xaml, sw.GetStringBuilder().Replace("  ", " ").ToString());
 		}
+		
+		[Test]
+		public void Write_ShouldSerializeObject()
+		{
+			if (!Compat.IsPortableXaml)
+			{
+				Assert.Ignore("This is not support in System.Xaml");
+			}
+			else
+			{
+				var instance = new ShouldSerializeInvisibleTest();
+				var actual = XamlServices.Save(instance);
+
+				Assert.IsEmpty(actual);
+			}
+		}
+		
+		[Test]
+		public void Write_ShoudSerializeObjectInCollection()
+		{
+			if (!Compat.IsPortableXaml)
+			{
+				Assert.Ignore("This is not support in System.Xaml");
+			}
+			else
+			{
+				var xaml = @"<ShouldSerializeInCollectionTest xmlns=""clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_netstandard20"" xmlns:scg=""clr-namespace:System.Collections.Generic;assembly=mscorlib"" xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+  <ShouldSerializeInCollectionTest.Collection>
+    <scg:List x:TypeArguments=""ShouldSerializeInvisibleTest"" Capacity=""4"">
+      <ShouldSerializeInvisibleTest IsVisibleInXml=""True"" Value=""This is visible"" />
+      <ShouldSerializeInvisibleTest IsVisibleInXml=""True"" Value=""This is visible"" />
+    </scg:List>
+  </ShouldSerializeInCollectionTest.Collection>
+</ShouldSerializeInCollectionTest>".UpdateXml();
+				
+				var instance = new ShouldSerializeInCollectionTest();
+				var actual = XamlServices.Save(instance);
+				Assert.AreEqual(xaml, actual);
+			}
+		}
 	}
 
 	public class TestXmlWriterClass1


### PR DESCRIPTION
This is new feature for Portable.Xaml.

Then we need to control serialization of ability we have the next instruments:

1) The DesignerSerializationVisibility attribute.
2) We can implement "ShouldSerialize[PropertyName]" method name returns the bool and takes 0 arguments.

Now we can't control the object serialization. This PR add this ability. This is initial implementation and we can discuss this.
