### PR TITLE
Yet another one UsableDuringInitialization fix related to collections

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -483,13 +483,17 @@ namespace Portable.Xaml
 
 						if (state.Type.IsUsableDuringInitialization)
 						{
-							if (!AddToCollectionIfAppropriate(parent_state.Type, parent_state.CurrentMember, parent_state.Value, state.Value, state.KeyValue) && 
-							    !parent_state.CurrentMemberState.IsAlreadySet)
+							// Make sure that we invoke this block only once, while setting the very first property.
+							if (state.WrittenProperties.Count == 1)
 							{
-								SetValue(parent_state.CurrentMember, parent_state.Value, state.Value);
-							}
+								if (!AddToCollectionIfAppropriate(parent_state.Type, parent_state.CurrentMember, parent_state.Value, state.Value, state.KeyValue) && 
+								    !parent_state.CurrentMemberState.IsAlreadySet)
+								{
+									SetValue(parent_state.CurrentMember, parent_state.Value, state.Value);
+								}
 
-							parent_state.CurrentMemberState.IsAlreadySet = true;
+								parent_state.CurrentMemberState.IsAlreadySet = true;
+							}
 						}
 					}
 				}

--- a/src/Test/System.Xaml/TestedTypes.cs
+++ b/src/Test/System.Xaml/TestedTypes.cs
@@ -420,6 +420,8 @@ namespace MonoTests.Portable.Xaml
 	{
 		public TestClass7 Foo { get; set; }
 
+		public int Bar { get; set; }
+
 		public string Baz { get; set; }
 
 		public bool IsInitialized { get; private set;}
@@ -449,6 +451,7 @@ namespace MonoTests.Portable.Xaml
 				foreach (TestClass9 item in args.NewItems)
 				{
 					Assert.IsFalse(item.IsInitialized);
+					Assert.Zero(item.Bar);
 					Assert.IsNull(item.Baz);
 				}
 			};

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2350,15 +2350,22 @@ $@"<TestClass7
 					<TestClass9 Baz='Test1' Bar='42'/>
 					<TestClass9 Baz='Test2'/>
 					<TestClass9/>
+					<TestClass9/>
 				  </TestClass10>".UpdateXml();
 
 			// Note: The most important assert is invoked inside the TestClass10 (CollectionChanged).
 			var result = (TestClass10)XamlServices.Parse(xml);
-			Assert.AreEqual(3, result.Items.Count);
+
+			Assert.AreEqual(4, result.Items.Count);
+
 			Assert.AreEqual("Test1", result.Items[0].Baz);
 			Assert.AreEqual(42, result.Items[0].Bar);
+
 			Assert.AreEqual("Test2", result.Items[1].Baz);
+			Assert.Zero(result.Items[1].Bar);
+
 			Assert.IsNull(result.Items[2].Baz);
+			Assert.Zero(result.Items[2].Bar);
 		}
 		
 		[Test]

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -2347,7 +2347,7 @@ $@"<TestClass7
 		{
 			string xml =
 				@"<TestClass10 xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly=Portable.Xaml_test_net_4_0'>
-					<TestClass9 Baz='Test1'/>
+					<TestClass9 Baz='Test1' Bar='42'/>
 					<TestClass9 Baz='Test2'/>
 					<TestClass9/>
 				  </TestClass10>".UpdateXml();
@@ -2356,6 +2356,7 @@ $@"<TestClass7
 			var result = (TestClass10)XamlServices.Parse(xml);
 			Assert.AreEqual(3, result.Items.Count);
 			Assert.AreEqual("Test1", result.Items[0].Baz);
+			Assert.AreEqual(42, result.Items[0].Bar);
 			Assert.AreEqual("Test2", result.Items[1].Baz);
 			Assert.IsNull(result.Items[2].Baz);
 		}


### PR DESCRIPTION
I have found that if UsableDuringInitialization(true) object has more than one property set in XAML, such an object would be attached to a parent collection multiple times. Unfortunately, my previous test did not cover this scenario. So this PR includes both the updated test, and the fix.