### PR TITLE
Return the unknown type instead null for more readable user errors

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ParsedMarkupExtensionInfo.cs
@@ -353,7 +353,10 @@ namespace Portable.Xaml
 				throw Error ("Failed to parse type name '{0}'", Name);
 
 			var xtnFirst = new XamlTypeName(xtn.Namespace, xtn.Name + "Extension", xtn.TypeArguments);
-			Type = sctx.GetXamlType (xtnFirst) ??
+			var xtFirst = sctx.GetXamlType(xtnFirst);
+			
+			//if type with Extension postfix is not resolved or unknown we try to get it without the prefix 
+			Type = ((xtFirst == null || xtFirst.IsUnknown)? null: xtFirst) ??
 				sctx.GetXamlType(xtn) ??
 				new XamlType(xtn.Namespace, xtn.Name, null, sctx);
 

--- a/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlSchemaContext.cs
@@ -679,12 +679,13 @@ namespace Portable.Xaml
 
 
 			// ensure only the referenced types are allowed
-			if (
-				ret == null
-				|| (reference_assemblies != null && !reference_assemblies.Contains(ret.GetTypeInfo().Assembly))
-			)
+			if ((reference_assemblies != null && !reference_assemblies.Contains(ret.GetTypeInfo().Assembly)))
 				return null;
 
+			// we need to return the unknown type instead of null for more readable errors
+			if(ret == null)
+				return new XamlType(xmlNamespace, xmlLocalName, null, this);
+			
 			return GetXamlType(genArgs == null ? ret : ret.MakeGenericType(genArgs));
 		}
 

--- a/src/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -1580,5 +1580,23 @@ namespace MonoTests.Portable.Xaml
 				return unknownTypeNames.Contains(name) ? null : base.GetXamlType(xamlNamespace, name, typeArguments);
 			}
 		}
+		
+		[Test]
+		public void More_Readable_Error_Info()
+		{
+			var assembly = this.GetType().GetTypeInfo().Assembly.FullName;
+			var xaml = $@"<CollectionParentItem xmlns='clr-namespace:MonoTests.Portable.Xaml;assembly={assembly}'>
+	Hello
+    <CollectionIte />
+	!
+</CollectionParentItem>";
+
+			Assert.Catch<XamlObjectWriterException>(() =>
+			{
+				var res = ((CollectionParentItem) XamlServices.Parse(xaml));
+			});
+
+
+		}
 	}
 }


### PR DESCRIPTION
This PR changes the behavior of Portable.Xaml to same as the System.Xaml.

During reading the xaml if the type not found we return instance of the XamlType with IsUnknow = true

Restored https://github.com/cwensley/Portable.Xaml/pull/141