### PR TITLE
Add support for IgnoreDataMemberAttribute

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/XamlMember.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlMember.cs
@@ -29,6 +29,7 @@ using Portable.Xaml.Schema;
 using System.Linq;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 
 namespace Portable.Xaml
 {
@@ -226,6 +227,16 @@ namespace Portable.Xaml
 		}
 #endif
 
+		internal bool IgnoreDataMember
+		{
+			get
+			{
+				var c = this.CustomAttributeProvider;
+				var a = c == null ? null : c.GetCustomAttribute<IgnoreDataMemberAttribute>(false);
+				return a != null;
+			}
+		}
+
 		internal bool ShouldSerialize(object instance)
 		{
 			var shouldSerialize = flags.Get(MemberFlags.ShouldSerialize) ?? flags.Set(MemberFlags.ShouldSerialize, LookupShouldSerialize());
@@ -262,6 +273,8 @@ namespace Portable.Xaml
 #if !PCL || NETSTANDARD
 			shouldSerialize &= SerializationVisibility != DesignerSerializationVisibility.Hidden;
 #endif
+			shouldSerialize &= !IgnoreDataMember;
+
 			return shouldSerialize;
 		}
 

--- a/src/Test/System.Xaml/XamlMemberTest.cs
+++ b/src/Test/System.Xaml/XamlMemberTest.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -25,6 +25,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 using System.Text;
 using NUnit.Framework;
 using MonoTests.Portable.Xaml.NamespaceTest;
@@ -52,6 +53,7 @@ namespace MonoTests.Portable.Xaml
 		EventInfo eventStore_Event3 = typeof (EventStore).GetEvent ("Event3");
 		PropertyInfo str_len = typeof (string).GetProperty ("Length");
 		PropertyInfo sb_len = typeof (StringBuilder).GetProperty ("Length");
+		PropertyInfo dummy_ignored_prop = typeof(XamlMemberTest).GetProperty ("DummyIgnoredProp");
 		MethodInfo dummy_add = typeof (XamlMemberTest).GetMethod ("DummyAddMethod");
 		MethodInfo dummy_get = typeof (XamlMemberTest).GetMethod ("DummyGetMethod");
 		MethodInfo dummy_set = typeof (XamlMemberTest).GetMethod ("DummySetMethod");
@@ -270,6 +272,17 @@ namespace MonoTests.Portable.Xaml
 			public void DummySetMethod (object o, int v)
 			{
 			}
+		}
+
+		[IgnoreDataMember]
+		public int DummyIgnoredProp { get; set; }
+
+		[Test]
+		public void ShouldNotSerializeIgnoredDataMember()
+		{
+			var m = new XamlMember (dummy_ignored_prop, sctx);
+			var b = m.ShouldSerialize(null);
+			Assert.IsFalse(b, "#1");
 		}
 
 		[Test]


### PR DESCRIPTION
## Add support for IgnoreDataMemberAttribute

[MSDN](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.ignoredatamemberattribute?view=netcore-3.0)

Fixes part of #144