### PR TITLE
UriTypeConverter should expect absolute and relative Uris.

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml.ComponentModel/UriTypeConverter.cs
+++ b/src/Portable.Xaml/Portable.Xaml.ComponentModel/UriTypeConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Globalization;
 using System.Reflection;
@@ -25,7 +25,7 @@ namespace Portable.Xaml.ComponentModel
 		{
 			var text = value as string;
 			if (text != null)
-				return new Uri(text);
+				return new Uri(text, UriKind.RelativeOrAbsolute);
 			return base.ConvertFrom (context, culture, value);
 		}
 

--- a/src/Test/System.Xaml/XamlObjectWriterTest.cs
+++ b/src/Test/System.Xaml/XamlObjectWriterTest.cs
@@ -931,6 +931,16 @@ namespace Tests.Portable.Xaml
 		}
 
 		[Test]
+		public void Write_UriRelative()
+		{
+			using (var xr = GetReader("UriRelative.xml"))
+			{
+				var des = XamlServices.Load(xr);
+				Assert.AreEqual(new Uri("./relative/uri", UriKind.Relative), des, "#1");
+			}
+		}
+
+		[Test]
 		public void Write_Null()
 		{
 			using (var xr = GetReader("NullExtension.xml"))

--- a/src/Test/XmlFiles/UriRelative.xml
+++ b/src/Test/XmlFiles/UriRelative.xml
@@ -1,0 +1,1 @@
+<x:Uri xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">./relative/uri</x:Uri>


### PR DESCRIPTION
(Like the UriTypeConverters from Micsosoft and and Mono.) Otherwise XAML with relative Uris can not be parsed with .net core and above.